### PR TITLE
Add multigpu support.

### DIFF
--- a/model.py
+++ b/model.py
@@ -114,7 +114,7 @@ class NNUE(pl.LightningModule):
 
       self.optimizer.step()
 
-    loss = torch.tensor([sum(loss.item() for loss in losses)])
+    loss = sum([loss.to(device=self.main_device, non_blocking=True) for loss in losses])
     self.log(loss_type, loss)
     return loss
 

--- a/model.py
+++ b/model.py
@@ -113,7 +113,7 @@ class NNUE(pl.LightningModule):
 
       self.optimizer.step()
 
-    loss = sum(losses) / len(losses)
+    loss = torch.tensor([sum(loss.item() for loss in losses) / len(losses)])
     self.log(loss_type, loss)
     return loss
 

--- a/model.py
+++ b/model.py
@@ -52,18 +52,18 @@ class NNUE(pl.LightningModule):
     self.lambda_ = lambda_
     self.feature_set = feature_set
 
-    self.model = nn.Sequential(
+    self.models = [nn.Sequential(
       FeatureTransformer(feature_set),
       nn.Linear(2 * L1, L2),
       nn.Hardtanh(min_val=0.0, max_val=1.0),
       nn.Linear(L2, L3),
       nn.Hardtanh(min_val=0.0, max_val=1.0),
-      nn.Linear(L3, 1)).to(self.main_device)
+      nn.Linear(L3, 1)).to(device) for device in self.devices]
 
-    self.optimizer = ranger.Ranger(self.parameters())
+    self.optimizer = ranger.Ranger(self.models[0].parameters())
 
   def forward(self, us, them, w_in, b_in):
-    return self.model((us, them, w_in, b_in))
+    return self.models[0]((us, them, w_in, b_in))
 
   def backward(self, loss, optimizer, optimizer_idx):
     # We override backward to do nothing because we want to do
@@ -76,16 +76,18 @@ class NNUE(pl.LightningModule):
     if len(uss) != len(self.devices):
       raise Exception('Number of batches doesn\'t match the number of devices')
 
-    local_models = [self.model] + [copy.deepcopy(self.model).to(device=device) for device in self.devices[1:]]
+    with torch.no_grad():
+      for model in self.models[1:]:
+        for param, main_param in zip(model.parameters(), self.models[0].parameters()):
+          param.copy_(main_param, non_blocking=True)
 
-    qs = [m((u, t, w, b)) for m, u, t, w, b in zip(local_models, uss, thems, whites, blacks)]
+    qs = [m((u, t, w, b)) for m, u, t, w, b in zip(self.models, uss, thems, whites, blacks)]
     ts = outcomes
     # Divide score by 600.0 to match the expected NNUE scaling factor
     ps = [(score / 600.0).sigmoid() for score in scores]
 
     return {
-      'losses' : [self.loss_fn(q=q, t=t, p=p) / len(self.devices) for q,t,p in zip(qs, ts, ps)],
-      'local_models' : local_models
+      'losses' : [self.loss_fn(q=q, t=t, p=p) / len(self.devices) for q,t,p in zip(qs, ts, ps)]
       }
 
     # MSE Loss function for debugging
@@ -95,20 +97,19 @@ class NNUE(pl.LightningModule):
 
   def step_end_(self, batch_parts, loss_type, do_optimization=False):
     losses = batch_parts['losses']
-    local_models = batch_parts['local_models']
 
     if do_optimization:
-      for m in local_models:
+      for m in self.models:
           for param in m.parameters():
               param.grad = None
 
       for loss in losses:
         loss.backward()
 
-      grads_by_model = [[param.grad.to(device=self.main_device, non_blocking=True) for param in m.parameters()] for m in local_models[1:]]
+      grads_by_model = [[param.grad.to(device=self.main_device, non_blocking=True) for param in m.parameters()] for m in self.models[1:]]
 
       for grads in grads_by_model:
-          for main_param, grad in zip(self.model.parameters(), grads):
+          for main_param, grad in zip(self.models[0].parameters(), grads):
               main_param.grad += grad
 
       self.optimizer.step()

--- a/model.py
+++ b/model.py
@@ -84,7 +84,7 @@ class NNUE(pl.LightningModule):
     ps = [(score / 600.0).sigmoid() for score in scores]
 
     return {
-      'losses' : [self.loss_fn(q=q, t=t, p=p) for q,t,p in zip(qs, ts, ps)],
+      'losses' : [self.loss_fn(q=q, t=t, p=p) / len(self.devices) for q,t,p in zip(qs, ts, ps)],
       'local_models' : local_models
       }
 
@@ -113,7 +113,7 @@ class NNUE(pl.LightningModule):
 
       self.optimizer.step()
 
-    loss = torch.tensor([sum(loss.item() for loss in losses) / len(losses)])
+    loss = torch.tensor([sum(loss.item() for loss in losses)])
     self.log(loss_type, loss)
     return loss
 

--- a/model.py
+++ b/model.py
@@ -90,11 +90,6 @@ class NNUE(pl.LightningModule):
       'losses' : [self.loss_fn(q=q, t=t, p=p) / len(self.devices) for q,t,p in zip(qs, ts, ps)]
       }
 
-    # MSE Loss function for debugging
-    # Scale score by 600.0 to match the expected NNUE scaling factor
-    # output = self(us, them, white, black) * 600.0
-    # loss = F.mse_loss(output, score)
-
   def step_end_(self, batch_parts, loss_type, do_optimization=False):
     losses = batch_parts['losses']
 

--- a/train.py
+++ b/train.py
@@ -50,6 +50,13 @@ def main():
   batch_size = args.batch_size
   if batch_size <= 0:
     batch_size = 128 if args.gpus == 0 else 8192
+
+  # Not sure where this should be done.
+  # We need to reduce the batch size by the number of used devices
+  # because we do one batch per device; the data loader produces
+  # N batches when there's N devices.
+  batch_size //= len(devices)
+
   print('Using batch size {}'.format(batch_size))
 
   if args.threads > 0:


### PR DESCRIPTION
This is a WIP PR to add multigpu (or rather, multidevice) support. Currently it's in a crude state and is not fully configurable through cli options. `--gpus` must NOT be passed, instead one has to modify the `devices = ['cuda:0']` in `train.py`. The code should work on multiple devices as it is. The main purpose of this draft is to ensure that this WORKS at all and that the results are correct. The performance when using one device should be unchanged. The performance when using multiple devices may not be good, this will be improved once we know this is working correctly.

To make this work with pytorch lightning I had to slightly abuse the `*_step_end` functions and override the `backward()` function with an empty one. Hopefully that's fine.

The code is based on my initial toy example here https://github.com/Sopel97/nnue-pytorch/blob/multigpu_research/test.py

@vondele I'd like to get your feedback as you're the only person I know who has multiple gpus to try this code. I've verified that this works in a cpu + gpu configuration, but I'd like to confirm this also works on multigpu configuration and possibly get some feedback regarding performance.

I would also like to get some feedback on some other stuff regarding this.
1. `--gpus` becomes unusable and MUST not be specified, otherwise pytorch lightning breaks things. Do we always do `args.gpus = None` and issue a warning if it's set?
2. How do we specify the devices used? This is not only limited to gpus with this code. I was thinking of `--devices=[cpu,cuda:0,cuda:1,whatever]`. Possibly take over `--gpus` parameter, but I'm not keen on parsing all possible syntaxes this parameter accepts in pytorch.
3. What do we do with the python data loader? I don't really know from the top of my head how to make it produce multiple batches, given that it uses pytorch DataLoader, and I don't feel like spending time on it.