### PR TITLE
Skip inCheck or capturing bestmoves

### DIFF
--- a/lib/nnue_training_data_formats.h
+++ b/lib/nnue_training_data_formats.h
@@ -6824,6 +6824,17 @@ namespace binpack
         {
             return pos.isMoveLegal(move);
         }
+
+        [[nodiscard]] bool isCapturingMove() const
+        {
+            return pos.pieceAt(move.to) != chess::Piece::none() &&
+                   pos.pieceAt(move.to).color() != pos.pieceAt(move.from).color(); // Exclude castling
+        }
+
+        [[nodiscard]] bool isInCheck() const
+        {
+            return pos.isCheck();
+        }
     };
 
     [[nodiscard]] inline TrainingDataEntry packedSfenValueToTrainingDataEntry(const nodchip::PackedSfenValue& psv)
@@ -7525,7 +7536,8 @@ namespace binpack
                                 isEnd = fetchNextChunkIfNeeded(m_offset, m_chunk);
                             }
 
-                            m_localBuffer.emplace_back(e);
+                            if (!e.isCapturingMove() && !e.isInCheck())
+                                m_localBuffer.emplace_back(e);
                         }
                         else
                         {
@@ -7547,7 +7559,8 @@ namespace binpack
                                 isEnd = fetchNextChunkIfNeeded(m_offset, m_chunk);
                             }
 
-                            m_localBuffer.emplace_back(e);
+                            if (!e.isCapturingMove() && !e.isInCheck())
+                                m_localBuffer.emplace_back(e);
                         }
 
                         if (isEnd || m_stopFlag.load())


### PR DESCRIPTION
this PR adds some code to the cpp data reader to skip positions where the (best)move is a capture or the position is in Check. 

Removing these positions from training data significantly improved results  in testing. 

While we can gensfen positions that satisfy these constraints, having it in the reader should make it easier to use data from other sources (fishtest)

@Sopel97 has ideas for a follow-up clean-up (i.e. pass a filter function instead of coding it at this low level).
