### PR TITLE
Refactor filtering.

### DIFF
--- a/train.py
+++ b/train.py
@@ -8,12 +8,12 @@ from torch import set_num_threads as t_set_num_threads
 from pytorch_lightning import loggers as pl_loggers
 from torch.utils.data import DataLoader, Dataset
 
-def data_loader_cc(train_filename, val_filename, num_workers, batch_size):
+def data_loader_cc(train_filename, val_filename, num_workers, batch_size, filtered):
   # Epoch and validation sizes are arbitrary
   epoch_size = 100000000
   val_size = 1000000
-  train_infinite = nnue_dataset.SparseBatchDataset(halfkp.FACTOR_NAME, train_filename, batch_size, num_workers=num_workers)
-  val_infinite = nnue_dataset.SparseBatchDataset(halfkp.FACTOR_NAME, val_filename, batch_size)
+  train_infinite = nnue_dataset.SparseBatchDataset(halfkp.FACTOR_NAME, train_filename, batch_size, num_workers=num_workers, filtered=filtered)
+  val_infinite = nnue_dataset.SparseBatchDataset(halfkp.FACTOR_NAME, val_filename, batch_size, filtered=filtered)
   # num_workers has to be 0 for sparse, and 1 for dense
   # it currently cannot work in parallel mode but it shouldn't need to
   train = DataLoader(nnue_dataset.FixedNumBatchesDataset(train_infinite, (epoch_size + batch_size - 1) // batch_size), batch_size=None, batch_sampler=None)
@@ -36,6 +36,7 @@ def main():
   parser.add_argument("--batch-size", default=-1, type=int, dest='batch_size', help="Number of positions per batch / per iteration. Default on GPU = 8192 on CPU = 128.")
   parser.add_argument("--threads", default=-1, type=int, dest='threads', help="Number of torch threads to use. Default automatic (cores) .")
   parser.add_argument("--seed", default=42, type=int, dest='seed', help="torch seed to use.")
+  parser.add_argument("--smart-fen-skipping", action='store_true', dest='smart_fen_skipping', help="If enabled positions that are bad training targets will be skipped during loading. Default: False")
   args = parser.parse_args()
 
   nnue = M.NNUE(halfkp, lambda_=args.lambda_)
@@ -50,6 +51,8 @@ def main():
     batch_size = 128 if args.gpus == 0 else 8192
   print('Using batch size {}'.format(batch_size))
 
+  print('Smart fen skipping: {}'.format(args.smart_fen_skipping))
+
   if args.threads > 0:
     print('limiting torch to {} threads.'.format(args.threads))
     t_set_num_threads(args.threads)
@@ -59,7 +62,7 @@ def main():
     train, val = data_loader_py(args.train, args.val, batch_size)
   else:
     print('Using c++ data loader')
-    train, val = data_loader_cc(args.train, args.val, args.num_workers, batch_size)
+    train, val = data_loader_cc(args.train, args.val, args.num_workers, batch_size, args.smart_fen_skipping)
 
   logdir = args.default_root_dir if args.default_root_dir else 'logs/'
   print('Using log dir {}'.format(logdir), flush=True)


### PR DESCRIPTION
Refactor position skipping to be easier to configure, more centralize…d, togglable by cli argument, and work for .bin. Add --smart-fen-skipping option (flag) that mimicks nodchip trainer option with the same name, default to false.

For parallel binpack loader the filtering happens in the worker threads during reading the binpack file. For non-parallel binpack reader and for bin readers the filtering happens at stream level. The predicate for skipping is configurable before stream construction. Filtering is dynamically togglable from python side.

Note that the python data loader still does not handle this option.