### PR TITLE
Cleanup model import/export with factorizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,11 @@ Import an existing SF NNUE network to the pytorch network format.
 python serialize.py nn.nnue converted.pt
 ```
 
+Import the network, with the factorizer enabled (for resuming training):
+```
+python serialize.py nn.nnue converted.pt --enable-factorizer
+```
+
 # Logging
 
 ```

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ python train.py --resume_from_checkpoint <path> ...
 python train.py --gpus 1 ...
 ```
 
+## Enable factorizer
+```
+python train.py --enable-factorizer ...
+```
+
 # Export a network
 
 Using either a checkpoint (`.ckpt`) or serialized model (`.pt`),
@@ -49,11 +54,6 @@ python serialize.py last.ckpt nn.nnue
 Import an existing SF NNUE network to the pytorch network format.
 ```
 python serialize.py nn.nnue converted.pt
-```
-
-Import the network, with the factorizer enabled (for resuming training):
-```
-python serialize.py nn.nnue converted.pt --enable-factorizer
 ```
 
 # Logging

--- a/halfkp.py
+++ b/halfkp.py
@@ -5,9 +5,26 @@ NUM_SQ = 64
 NUM_PT = 10
 NUM_PLANES = (NUM_SQ * NUM_PT + 1)
 
+def orient(is_white_pov: bool, sq: int):
+  return (63 * (not is_white_pov)) ^ sq
+
+def halfkp_idx(is_white_pov: bool, king_sq: int, sq: int, p: chess.Piece):
+  p_idx = (p.piece_type - 1) * 2 + (p.color != is_white_pov)
+  return 1 + orient(is_white_pov, sq) + p_idx * NUM_SQ + king_sq * NUM_PLANES
+
 class Features:
   name = 'HalfKP'
   inputs = NUM_PLANES * NUM_SQ # 41024
+
+  def get_indices(self, board: chess.Board):
+    def piece_indices(turn):
+      indices = torch.zeros(inputs)
+      for sq, p in board.piece_map().items():
+        if p.piece_type == chess.KING:
+          continue
+        indices[halfkp_idx(turn, orient(turn, board.king(turn)), sq, p)] = 1.0
+      return indices
+    return (piece_indices(chess.WHITE), piece_indices(chess.BLACK))
 
 # Factors are used by the trainer to share weights between common elements of
 # the features.
@@ -19,20 +36,28 @@ class Factorizer:
   }
   inputs = sum(factors.values())
 
-def orient(is_white_pov: bool, sq: int):
-  return (63 * (not is_white_pov)) ^ sq
+  def get_indices(self, board: chess.Board):
+    raise Exception('Not supported yet, you must use the c++ data loader for factorizer support during training')
 
-def halfkp_idx(is_white_pov: bool, king_sq: int, sq: int, p: chess.Piece):
-  p_idx = (p.piece_type - 1) * 2 + (p.color != is_white_pov)
-  return 1 + orient(is_white_pov, sq) + p_idx * NUM_SQ + king_sq * NUM_PLANES
+  def coalesce_weights(self, weights):
+    # incoming weights are in [256][INPUTS]
+    print('factorized shape:', weights.shape)
+    k_base = 41024
+    p_base = k_base + 64
+    result = []
+    # Goal here is to add together all the weights that would be active for the
+    # given piece and king position in the halfkp inputs.
+    for i in range(k_base):
+      k_idx = i // NUM_PLANES
+      p_idx = i % NUM_PLANES
+      w = weights.narrow(1, i, 1).clone()
+      # TODO - divide by 20 to approximate # of pieces on the board, but this is
+      # a huge hack.  Issue is there is only one king position set in the factored
+      # positions, but we add it's weights to the # of pieces on the board.  This
+      # vastly overweights the king value.
+      w = w + weights.narrow(1, k_base + k_idx, 1) / 20
+      if p_idx > 0:
+        w = w + weights.narrow(1, p_base + p_idx - 1, 1)
+      result.append(w)
+    return torch.cat(result, dim=1)
 
-def get_halfkp_indices(board: chess.Board):
-  # TODO - this doesn't support the factors yet.
-  def piece_indices(turn):
-    indices = torch.zeros(Features.inputs)
-    for sq, p in board.piece_map().items():
-      if p.piece_type == chess.KING:
-        continue
-      indices[halfkp_idx(turn, orient(turn, board.king(turn)), sq, p)] = 1.0
-    return indices
-  return (piece_indices(chess.WHITE), piece_indices(chess.BLACK))

--- a/halfkp.py
+++ b/halfkp.py
@@ -5,17 +5,19 @@ NUM_SQ = 64
 NUM_PT = 10
 NUM_PLANES = (NUM_SQ * NUM_PT + 1)
 
+class Features:
+  name = 'HalfKP'
+  inputs = NUM_PLANES * NUM_SQ # 41024
+
 # Factors are used by the trainer to share weights between common elements of
 # the features.
-FACTORS = {
-  'kings': 64,
-  'pieces': 640,
-}
-INPUTS = NUM_PLANES * NUM_SQ # 41024
-FACTOR_INPUTS = sum(FACTORS.values())
-INPUTS += FACTOR_INPUTS
-NAME = 'HalfKP'
-FACTOR_NAME = 'HalfKPFactorized'
+class Factorizer:
+  name = 'HalfKPFactorized'
+  factors = {
+    'kings': 64,
+    'pieces': 640,
+  }
+  inputs = sum(factors.values())
 
 def orient(is_white_pov: bool, sq: int):
   return (63 * (not is_white_pov)) ^ sq
@@ -27,7 +29,7 @@ def halfkp_idx(is_white_pov: bool, king_sq: int, sq: int, p: chess.Piece):
 def get_halfkp_indices(board: chess.Board):
   # TODO - this doesn't support the factors yet.
   def piece_indices(turn):
-    indices = torch.zeros(INPUTS)
+    indices = torch.zeros(Features.inputs)
     for sq, p in board.piece_map().items():
       if p.piece_type == chess.KING:
         continue

--- a/model.py
+++ b/model.py
@@ -23,16 +23,15 @@ class NNUE(pl.LightningModule):
   def __init__(self, feature_set=halfkp.Features(), factorizer=halfkp.Factorizer(), lambda_=1.0):
     super(NNUE, self).__init__()
     self.feature_set = feature_set
-    self.factorizer = factorizer
-    self.reset_weights()
+    self.change_factorizer(factorizer)
     self.l1 = nn.Linear(2 * L1, L2)
     self.l2 = nn.Linear(L2, L3)
     self.output = nn.Linear(L3, 1)
     self.lambda_ = lambda_
 
-  # Call after changing the factorizer (eg. loading a .nnue net, then enabling the factorizer
-  # for training.
-  def reset_weights(self):
+  # Call to change the factorizer.  Will reset the input weights to match the expected shape.
+  def change_factorizer(self, factorizer):
+    self.factorizer = factorizer
     num_inputs = self.feature_set.inputs
     if self.factorizer is not None:
       num_inputs += self.factorizer.inputs

--- a/model.py
+++ b/model.py
@@ -20,21 +20,30 @@ class NNUE(pl.LightningModule):
 
   It is not ideal for training a Pytorch quantized model directly.
   """
-  def __init__(self, feature_set=halfkp, lambda_=1.0):
+  def __init__(self, feature_set=halfkp.Features(), factorizer=halfkp.Factorizer(), lambda_=1.0):
     super(NNUE, self).__init__()
-    num_inputs = feature_set.INPUTS
-    self.input = nn.Linear(num_inputs, L1)
-
-    # Zero out the weights/biases for the factorized features
-    # Weights stored as [256][41024]
-    weights = self.input.weight.narrow(1, 0, feature_set.INPUTS - feature_set.FACTOR_INPUTS)
-    weights = torch.cat((weights, torch.zeros(L1, feature_set.FACTOR_INPUTS)), dim=1)
-    self.input.weight = nn.Parameter(weights)
-
+    self.feature_set = feature_set
+    self.factorizer = factorizer
+    self.reset_weights()
     self.l1 = nn.Linear(2 * L1, L2)
     self.l2 = nn.Linear(L2, L3)
     self.output = nn.Linear(L3, 1)
     self.lambda_ = lambda_
+
+  # Call after changing the factorizer (eg. loading a .nnue net, then enabling the factorizer
+  # for training.
+  def reset_weights(self):
+    num_inputs = self.feature_set.inputs
+    if self.factorizer is not None:
+      num_inputs += self.factorizer.inputs
+    self.input = nn.Linear(num_inputs, L1)
+
+    if self.factorizer is not None:
+      # Zero out the weights/biases for the factorized features
+      # Weights stored as [256][41024]
+      weights = self.input.weight.narrow(1, 0, self.feature_set.inputs)
+      weights = torch.cat((weights, torch.zeros(L1, self.factorizer.inputs)), dim=1)
+      self.input.weight = nn.Parameter(weights)
 
   def forward(self, us, them, w_in, b_in):
     w = self.input(w_in)

--- a/model.py
+++ b/model.py
@@ -35,7 +35,9 @@ class NNUE(pl.LightningModule):
     num_inputs = self.feature_set.inputs
     if self.factorizer is not None:
       num_inputs += self.factorizer.inputs
-    self.input = nn.Linear(num_inputs, L1)
+    # Don't reinitialize the weights if they've already been set.
+    if not hasattr(self, 'input'):
+      self.input = nn.Linear(num_inputs, L1)
 
     if self.factorizer is not None:
       # Zero out the weights/biases for the factorized features

--- a/nnue_bin_dataset.py
+++ b/nnue_bin_dataset.py
@@ -44,13 +44,16 @@ def is_quiet(board, from_, to_):
   return False
 
 class ToTensor(object):
+  def __init__(self):
+    self.features = halfkp.Features()
+
   def __call__(self, sample):
     bd, _, outcome, score = sample
     us = torch.tensor([bd.turn])
     them = torch.tensor([not bd.turn])
     outcome = torch.tensor([outcome])
     score = torch.tensor([score])
-    white, black = halfkp.get_halfkp_indices(bd)
+    white, black = self.features.get_indices(bd)
     return us.float(), them.float(), white.float(), black.float(), outcome.float(), score.float()
 
 class RandomFlip(object):

--- a/scripts/train.sh
+++ b/scripts/train.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-python train.py ../data/d5_2b.binpack ../data/d10_128000_6293.binpack --lambda 0.5 --gpus 1 --val_check_interval 2000 --threads 2 --batch-size 16384 --progress_bar_refresh_rate 20
+python train.py d8_128000_21865.binpack d8_128000_21865.binpack --lambda 1.0 --val_check_interval 2000 --threads 2 --batch-size 16384 --progress_bar_refresh_rate 20 --factorizer

--- a/scripts/train.sh
+++ b/scripts/train.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-python train.py d8_128000_21865.binpack d8_128000_21865.binpack --lambda 1.0 --val_check_interval 2000 --threads 2 --batch-size 16384 --progress_bar_refresh_rate 20 --factorizer
+python train.py d8_128000_21865.binpack d8_128000_21865.binpack --lambda 1.0 --val_check_interval 2000 --threads 2 --batch-size 16384 --progress_bar_refresh_rate 20 --enable-factorizer

--- a/serialize.py
+++ b/serialize.py
@@ -9,28 +9,6 @@ import torch
 import pytorch_lightning as pl
 from torch.utils.data import DataLoader
 
-def coalesce_weights(weights):
-  # incoming weights are in [256][INPUTS]
-  print('factorized shape:', weights.shape)
-  k_base = 41024
-  p_base = k_base + 64
-  result = []
-  # Goal here is to add together all the weights that would be active for the
-  # given piece and king position in the halfkp inputs.
-  for i in range(k_base):
-    k_idx = i // halfkp.NUM_PLANES
-    p_idx = i % halfkp.NUM_PLANES
-    w = weights.narrow(1, i, 1).clone()
-    # TODO - divide by 20 to approximate # of pieces on the board, but this is
-    # a huge hack.  Issue is there is only one king position set in the factored
-    # positions, but we add it's weights to the # of pieces on the board.  This
-    # vastly overweights the king value.
-    w = w + weights.narrow(1, k_base + k_idx, 1) / 20
-    if p_idx > 0:
-      w = w + weights.narrow(1, p_base + p_idx - 1, 1)
-    result.append(w)
-  return torch.cat(result, dim=1)
-
 def ascii_hist(name, x, bins=6):
   N,X = numpy.histogram(x, bins=bins)
   total = 1.0*len(x)
@@ -52,7 +30,7 @@ class NNUEWriter():
 
     self.write_header()
     self.int32(0x5d69d7b8) # Feature transformer hash
-    self.write_feature_transformer(model.input)
+    self.write_feature_transformer(model.factorizer, model.input)
     self.int32(0x63337156) # FC layers hash
     self.write_fc_layer(model.l1)
     self.write_fc_layer(model.l2)
@@ -67,7 +45,7 @@ class NNUEWriter():
     self.int32(len(description)) # Network definition
     self.buf.extend(description)
 
-  def write_feature_transformer(self, layer):
+  def write_feature_transformer(self, factorizer, layer):
     # int16 bias = round(x * 127)
     # int16 weight = round(x * 127)
     bias = layer.bias.data
@@ -76,7 +54,8 @@ class NNUEWriter():
     self.buf.extend(bias.flatten().numpy().tobytes())
 
     weight = layer.weight.data
-    weight = coalesce_weights(weight)
+    if factorizer is not None:
+      weight = factorizer.coalesce_weights(weight)
     weight = weight.mul(127).round().to(torch.int16)
     ascii_hist('ft weight:', weight.numpy())
     # weights stored as [41024][256], so we need to transpose the pytorch [256][41024]
@@ -192,7 +171,14 @@ def main():
     if args.source.endswith(".pt"):
       nnue = torch.load(args.source)
     else:
-      nnue = M.NNUE.load_from_checkpoint(args.source)
+      # This try/catch is not ideal, but we don't know if we are converting
+      # a factorized checkpoint, or an unfactorized one.
+      try:
+        # First try with defaults (factorizer on).
+        nnue = M.NNUE.load_from_checkpoint(args.source)
+      except:
+        # If that fails, then try with factorizer disaabled.
+        nnue = M.NNUE.load_from_checkpoint(args.source, factorizer=None)
     nnue.eval()
     writer = NNUEWriter(nnue)
     with open(args.target, 'wb') as f:

--- a/train.py
+++ b/train.py
@@ -38,7 +38,7 @@ def main():
   parser.add_argument("--threads", default=-1, type=int, dest='threads', help="Number of torch threads to use. Default automatic (cores) .")
   parser.add_argument("--seed", default=42, type=int, dest='seed', help="torch seed to use.")
   parser.add_argument("--smart-fen-skipping", action='store_true', dest='smart_fen_skipping', help="If enabled positions that are bad training targets will be skipped during loading. Default: False")
-  parser.add_argument("--factorizer", action='store_true', dest='factorizer', help="Enables using the factorizer for training.")
+  parser.add_argument("--enable-factorizer", dest='enable_factorizer', action='store_true', help="Enables using the factorizer for training.")
   parser.add_argument("--resume-from-model", dest='resume_from_model', help="Initializes training using the weights from the given .pt model")
   args = parser.parse_args()
 
@@ -46,7 +46,7 @@ def main():
 
   factorizer = None
   features_name = features.Features.name
-  if args.factorizer:
+  if args.enable_factorizer:
     factorizer = features.Factorizer()
     features_name = factorizer.name
 
@@ -66,7 +66,7 @@ def main():
   print('Using batch size {}'.format(batch_size))
 
   print('Smart fen skipping: {}'.format(args.smart_fen_skipping))
-  print('Factorizer: {}'.format(args.factorizer))
+  print('Factorizer: {}'.format(args.enable_factorizer))
 
   if args.threads > 0:
     print('limiting torch to {} threads.'.format(args.threads))

--- a/train.py
+++ b/train.py
@@ -4,16 +4,17 @@ import nnue_dataset
 import nnue_bin_dataset
 import pytorch_lightning as pl
 import halfkp
+import torch
 from torch import set_num_threads as t_set_num_threads
 from pytorch_lightning import loggers as pl_loggers
 from torch.utils.data import DataLoader, Dataset
 
-def data_loader_cc(train_filename, val_filename, num_workers, batch_size, filtered):
+def data_loader_cc(train_filename, val_filename, features_name, num_workers, batch_size, filtered):
   # Epoch and validation sizes are arbitrary
   epoch_size = 100000000
   val_size = 1000000
-  train_infinite = nnue_dataset.SparseBatchDataset(halfkp.FACTOR_NAME, train_filename, batch_size, num_workers=num_workers, filtered=filtered)
-  val_infinite = nnue_dataset.SparseBatchDataset(halfkp.FACTOR_NAME, val_filename, batch_size, filtered=filtered)
+  train_infinite = nnue_dataset.SparseBatchDataset(features_name, train_filename, batch_size, num_workers=num_workers, filtered=filtered)
+  val_infinite = nnue_dataset.SparseBatchDataset(features_name, val_filename, batch_size, filtered=filtered)
   # num_workers has to be 0 for sparse, and 1 for dense
   # it currently cannot work in parallel mode but it shouldn't need to
   train = DataLoader(nnue_dataset.FixedNumBatchesDataset(train_infinite, (epoch_size + batch_size - 1) // batch_size), batch_size=None, batch_sampler=None)
@@ -37,9 +38,22 @@ def main():
   parser.add_argument("--threads", default=-1, type=int, dest='threads', help="Number of torch threads to use. Default automatic (cores) .")
   parser.add_argument("--seed", default=42, type=int, dest='seed', help="torch seed to use.")
   parser.add_argument("--smart-fen-skipping", action='store_true', dest='smart_fen_skipping', help="If enabled positions that are bad training targets will be skipped during loading. Default: False")
+  parser.add_argument("--factorizer", action='store_true', dest='factorizer', help="Enables using the factorizer for training.")
+  parser.add_argument("--resume-from-model", dest='resume_from_model', help="Initializes training using the weights from the given .pt model")
   args = parser.parse_args()
 
-  nnue = M.NNUE(halfkp, lambda_=args.lambda_)
+  features = halfkp
+
+  factorizer = None
+  features_name = features.Features.name
+  if args.factorizer:
+    factorizer = features.Factorizer()
+    features_name = factorizer.name
+
+  if args.resume_from_model is None:
+    nnue = M.NNUE(feature_set=features.Features(), factorizer=factorizer, lambda_=args.lambda_)
+  else:
+    nnue = torch.load(args.resume_from_model)
 
   print("Training with {} validating with {}".format(args.train, args.val))
 
@@ -52,6 +66,7 @@ def main():
   print('Using batch size {}'.format(batch_size))
 
   print('Smart fen skipping: {}'.format(args.smart_fen_skipping))
+  print('Factorizer: {}'.format(args.factorizer))
 
   if args.threads > 0:
     print('limiting torch to {} threads.'.format(args.threads))
@@ -62,7 +77,7 @@ def main():
     train, val = data_loader_py(args.train, args.val, batch_size)
   else:
     print('Using c++ data loader')
-    train, val = data_loader_cc(args.train, args.val, args.num_workers, batch_size, args.smart_fen_skipping)
+    train, val = data_loader_cc(args.train, args.val, features_name, args.num_workers, batch_size, args.smart_fen_skipping)
 
   logdir = args.default_root_dir if args.default_root_dir else 'logs/'
   print('Using log dir {}'.format(logdir), flush=True)

--- a/train.py
+++ b/train.py
@@ -54,6 +54,8 @@ def main():
     nnue = M.NNUE(feature_set=features.Features(), factorizer=factorizer, lambda_=args.lambda_)
   else:
     nnue = torch.load(args.resume_from_model)
+    nnue.change_factorizer(factorizer)
+    nnue.lambda_ = args.lambda_
 
   print("Training with {} validating with {}".format(args.train, args.val))
 


### PR DESCRIPTION
@vondele @Sopel97 

train.py
- Adds `--enable-factorizer` option.  Default is false, which will train without factorizer.  Factorizer on or off dynamically modifies the model shape, so you can resume non-factorized nets in factorizer mode.
- Adds `--reuse-from-model` option.  Pass in a serialized model, ending in `.pt`, to resume from those weights.

serialize.py: 
- Fixes nnue -> pt, as they need to be imported without factorizer shapes.
- Supports both factorized and non-factorized pt -> nnue conversions.