### PR TITLE
Pass feature counts and remove the magic `20` constant for halfk factorizer.

### DIFF
--- a/halfkp.py
+++ b/halfkp.py
@@ -51,11 +51,7 @@ class Factorizer:
       k_idx = i // NUM_PLANES
       p_idx = i % NUM_PLANES
       w = weights.narrow(1, i, 1).clone()
-      # TODO - divide by 20 to approximate # of pieces on the board, but this is
-      # a huge hack.  Issue is there is only one king position set in the factored
-      # positions, but we add it's weights to the # of pieces on the board.  This
-      # vastly overweights the king value.
-      w = w + weights.narrow(1, k_base + k_idx, 1) / 20
+      w = w + weights.narrow(1, k_base + k_idx, 1)
       if p_idx > 0:
         w = w + weights.narrow(1, p_base + p_idx - 1, 1)
       result.append(w)

--- a/nnue_dataset.py
+++ b/nnue_dataset.py
@@ -23,7 +23,9 @@ class SparseBatch(ctypes.Structure):
         ('num_active_white_features', ctypes.c_int),
         ('num_active_black_features', ctypes.c_int),
         ('white', ctypes.POINTER(ctypes.c_int)),
-        ('black', ctypes.POINTER(ctypes.c_int))
+        ('black', ctypes.POINTER(ctypes.c_int)),
+        ('white_values', ctypes.POINTER(ctypes.c_float)),
+        ('black_values', ctypes.POINTER(ctypes.c_float))
     ]
 
     def get_tensors(self):
@@ -33,8 +35,10 @@ class SparseBatch(ctypes.Structure):
         score = torch.from_numpy(np.ctypeslib.as_array(self.score, shape=(self.size, 1))).clone()
         iw = torch.from_numpy(np.ctypeslib.as_array(self.white, shape=(self.num_active_white_features, 2)).transpose()).clone()
         ib = torch.from_numpy(np.ctypeslib.as_array(self.black, shape=(self.num_active_white_features, 2)).transpose()).clone()
-        white = torch.sparse.FloatTensor(iw.long(), torch.ones((self.num_active_white_features), dtype=torch.float32), (self.size, self.num_inputs))
-        black = torch.sparse.FloatTensor(ib.long(), torch.ones((self.num_active_black_features), dtype=torch.float32), (self.size, self.num_inputs))
+        white_values = torch.from_numpy(np.ctypeslib.as_array(self.white_values, shape=(self.num_active_white_features,))).clone()
+        black_values = torch.from_numpy(np.ctypeslib.as_array(self.black_values, shape=(self.num_active_black_features,))).clone()
+        white = torch.sparse.FloatTensor(iw.long(), white_values, (self.size, self.num_inputs))
+        black = torch.sparse.FloatTensor(ib.long(), black_values, (self.size, self.num_inputs))
         return us, them, white, black, outcome, score
 
 SparseBatchPtr = ctypes.POINTER(SparseBatch)


### PR DESCRIPTION
This PR adds value arrays in the sparse batch that stand for the feature count. Now all features for a single position should have unique indices, but may have different counts (weights).

This is untested, please verify that there are no obvious mistakes.