### PR TITLE
Optimize training

### DIFF
--- a/nnue_dataset.py
+++ b/nnue_dataset.py
@@ -39,6 +39,8 @@ class SparseBatch(ctypes.Structure):
         black_values = torch.from_numpy(np.ctypeslib.as_array(self.black_values, shape=(self.num_active_black_features,))).pin_memory().cuda(non_blocking=True)
         white = torch._sparse_coo_tensor_unsafe(iw.long(), white_values, (self.size, self.num_inputs))
         black = torch._sparse_coo_tensor_unsafe(ib.long(), black_values, (self.size, self.num_inputs))
+        white._coalesced_(True)
+        black._coalesced_(True)
         return us, them, white, black, outcome, score
 
 SparseBatchPtr = ctypes.POINTER(SparseBatch)

--- a/nnue_dataset.py
+++ b/nnue_dataset.py
@@ -28,15 +28,15 @@ class SparseBatch(ctypes.Structure):
         ('black_values', ctypes.POINTER(ctypes.c_float))
     ]
 
-    def get_tensors(self):
-        white_values = torch.from_numpy(np.ctypeslib.as_array(self.white_values, shape=(self.num_active_white_features,))).pin_memory().cuda(non_blocking=True)
-        black_values = torch.from_numpy(np.ctypeslib.as_array(self.black_values, shape=(self.num_active_black_features,))).pin_memory().cuda(non_blocking=True)
-        iw = torch.transpose(torch.from_numpy(np.ctypeslib.as_array(self.white, shape=(self.num_active_white_features, 2))).pin_memory().cuda(non_blocking=True), 0, 1).long()
-        ib = torch.transpose(torch.from_numpy(np.ctypeslib.as_array(self.black, shape=(self.num_active_white_features, 2))).pin_memory().cuda(non_blocking=True), 0, 1).long()
-        us = torch.from_numpy(np.ctypeslib.as_array(self.is_white, shape=(self.size, 1))).pin_memory().cuda(non_blocking=True)
+    def get_tensors(self, device):
+        white_values = torch.from_numpy(np.ctypeslib.as_array(self.white_values, shape=(self.num_active_white_features,))).pin_memory().to(device=device, non_blocking=True)
+        black_values = torch.from_numpy(np.ctypeslib.as_array(self.black_values, shape=(self.num_active_black_features,))).pin_memory().to(device=device, non_blocking=True)
+        iw = torch.transpose(torch.from_numpy(np.ctypeslib.as_array(self.white, shape=(self.num_active_white_features, 2))).pin_memory().to(device=device, non_blocking=True), 0, 1).long()
+        ib = torch.transpose(torch.from_numpy(np.ctypeslib.as_array(self.black, shape=(self.num_active_white_features, 2))).pin_memory().to(device=device, non_blocking=True), 0, 1).long()
+        us = torch.from_numpy(np.ctypeslib.as_array(self.is_white, shape=(self.size, 1))).pin_memory().to(device=device, non_blocking=True)
         them = 1.0 - us
-        outcome = torch.from_numpy(np.ctypeslib.as_array(self.outcome, shape=(self.size, 1))).pin_memory().cuda(non_blocking=True)
-        score = torch.from_numpy(np.ctypeslib.as_array(self.score, shape=(self.size, 1))).pin_memory().cuda(non_blocking=True)
+        outcome = torch.from_numpy(np.ctypeslib.as_array(self.outcome, shape=(self.size, 1))).pin_memory().to(device=device, non_blocking=True)
+        score = torch.from_numpy(np.ctypeslib.as_array(self.score, shape=(self.size, 1))).pin_memory().to(device=device, non_blocking=True)
         white = torch._sparse_coo_tensor_unsafe(iw, white_values, (self.size, self.num_inputs))
         black = torch._sparse_coo_tensor_unsafe(ib, black_values, (self.size, self.num_inputs))
         white._coalesced_(True)
@@ -57,7 +57,8 @@ class TrainingDataProvider:
         cyclic,
         num_workers,
         batch_size=None,
-        filtered=False):
+        filtered=False,
+        device='cpu'):
 
         self.feature_set = feature_set.encode('utf-8')
         self.create_stream = create_stream
@@ -69,6 +70,7 @@ class TrainingDataProvider:
         self.num_workers = num_workers
         self.batch_size = batch_size
         self.filtered = filtered
+        self.device = device
 
         if batch_size:
             self.stream = self.create_stream(self.feature_set, self.num_workers, self.filename, batch_size, cyclic, filtered)
@@ -82,7 +84,7 @@ class TrainingDataProvider:
         v = self.fetch_next(self.stream)
 
         if v:
-            tensors = v.contents.get_tensors()
+            tensors = v.contents.get_tensors(self.device)
             self.destroy_part(v)
             return tensors
         else:
@@ -103,7 +105,7 @@ fetch_next_sparse_batch.argtypes = [ctypes.c_void_p]
 destroy_sparse_batch = dll.destroy_sparse_batch
 
 class SparseBatchProvider(TrainingDataProvider):
-    def __init__(self, feature_set, filename, batch_size, cyclic=True, num_workers=1, filtered=False):
+    def __init__(self, feature_set, filename, batch_size, cyclic=True, num_workers=1, filtered=False, device='cpu'):
         super(SparseBatchProvider, self).__init__(
             feature_set,
             create_sparse_batch_stream,
@@ -114,10 +116,11 @@ class SparseBatchProvider(TrainingDataProvider):
             cyclic,
             num_workers,
             batch_size,
-            filtered)
+            filtered,
+            device)
 
 class SparseBatchDataset(torch.utils.data.IterableDataset):
-  def __init__(self, feature_set, filename, batch_size, cyclic=True, num_workers=1, filtered=False):
+  def __init__(self, feature_set, filename, batch_size, cyclic=True, num_workers=1, filtered=False, device='cpu'):
     super(SparseBatchDataset).__init__()
     self.feature_set = feature_set
     self.filename = filename
@@ -125,9 +128,10 @@ class SparseBatchDataset(torch.utils.data.IterableDataset):
     self.cyclic = cyclic
     self.num_workers = num_workers
     self.filtered = filtered
+    self.device = device
 
   def __iter__(self):
-    return SparseBatchProvider(self.feature_set, self.filename, self.batch_size, cyclic=self.cyclic, num_workers=self.num_workers, filtered=self.filtered)
+    return SparseBatchProvider(self.feature_set, self.filename, self.batch_size, cyclic=self.cyclic, num_workers=self.num_workers, filtered=self.filtered, device=self.device)
 
 class FixedNumBatchesDataset(Dataset):
   def __init__(self, dataset, num_batches):

--- a/nnue_dataset.py
+++ b/nnue_dataset.py
@@ -29,16 +29,16 @@ class SparseBatch(ctypes.Structure):
     ]
 
     def get_tensors(self):
-        us = torch.from_numpy(np.ctypeslib.as_array(self.is_white, shape=(self.size, 1))).clone()
+        us = torch.from_numpy(np.ctypeslib.as_array(self.is_white, shape=(self.size, 1))).pin_memory().cuda(non_blocking=True)
         them = 1.0 - us
-        outcome = torch.from_numpy(np.ctypeslib.as_array(self.outcome, shape=(self.size, 1))).clone()
-        score = torch.from_numpy(np.ctypeslib.as_array(self.score, shape=(self.size, 1))).clone()
-        iw = torch.from_numpy(np.ctypeslib.as_array(self.white, shape=(self.num_active_white_features, 2)).transpose()).clone()
-        ib = torch.from_numpy(np.ctypeslib.as_array(self.black, shape=(self.num_active_white_features, 2)).transpose()).clone()
-        white_values = torch.from_numpy(np.ctypeslib.as_array(self.white_values, shape=(self.num_active_white_features,))).clone()
-        black_values = torch.from_numpy(np.ctypeslib.as_array(self.black_values, shape=(self.num_active_black_features,))).clone()
-        white = torch.sparse.FloatTensor(iw.long(), white_values, (self.size, self.num_inputs))
-        black = torch.sparse.FloatTensor(ib.long(), black_values, (self.size, self.num_inputs))
+        outcome = torch.from_numpy(np.ctypeslib.as_array(self.outcome, shape=(self.size, 1))).pin_memory().cuda(non_blocking=True)
+        score = torch.from_numpy(np.ctypeslib.as_array(self.score, shape=(self.size, 1))).pin_memory().cuda(non_blocking=True)
+        iw = torch.from_numpy(np.ctypeslib.as_array(self.white, shape=(self.num_active_white_features, 2)).transpose()).pin_memory().cuda(non_blocking=True)
+        ib = torch.from_numpy(np.ctypeslib.as_array(self.black, shape=(self.num_active_white_features, 2)).transpose()).pin_memory().cuda(non_blocking=True)
+        white_values = torch.from_numpy(np.ctypeslib.as_array(self.white_values, shape=(self.num_active_white_features,))).pin_memory().cuda(non_blocking=True)
+        black_values = torch.from_numpy(np.ctypeslib.as_array(self.black_values, shape=(self.num_active_black_features,))).pin_memory().cuda(non_blocking=True)
+        white = torch._sparse_coo_tensor_unsafe(iw.long(), white_values, (self.size, self.num_inputs))
+        black = torch._sparse_coo_tensor_unsafe(ib.long(), black_values, (self.size, self.num_inputs))
         return us, them, white, black, outcome, score
 
 SparseBatchPtr = ctypes.POINTER(SparseBatch)

--- a/train.py
+++ b/train.py
@@ -9,19 +9,19 @@ from torch import set_num_threads as t_set_num_threads
 from pytorch_lightning import loggers as pl_loggers
 from torch.utils.data import DataLoader, Dataset
 
-def data_loader_cc(train_filename, val_filename, features_name, num_workers, batch_size, filtered):
+def data_loader_cc(train_filename, val_filename, features_name, num_workers, batch_size, filtered, main_device):
   # Epoch and validation sizes are arbitrary
   epoch_size = 100000000
   val_size = 1000000
-  train_infinite = nnue_dataset.SparseBatchDataset(features_name, train_filename, batch_size, num_workers=num_workers, filtered=filtered)
-  val_infinite = nnue_dataset.SparseBatchDataset(features_name, val_filename, batch_size, filtered=filtered)
+  train_infinite = nnue_dataset.SparseBatchDataset(features_name, train_filename, batch_size, num_workers=num_workers, filtered=filtered, device=main_device)
+  val_infinite = nnue_dataset.SparseBatchDataset(features_name, val_filename, batch_size, filtered=filtered, device=main_device)
   # num_workers has to be 0 for sparse, and 1 for dense
   # it currently cannot work in parallel mode but it shouldn't need to
   train = DataLoader(nnue_dataset.FixedNumBatchesDataset(train_infinite, (epoch_size + batch_size - 1) // batch_size), batch_size=None, batch_sampler=None)
   val = DataLoader(nnue_dataset.FixedNumBatchesDataset(val_infinite, (val_size + batch_size - 1) // batch_size), batch_size=None, batch_sampler=None)
   return train, val
 
-def data_loader_py(train_filename, val_filename, batch_size):
+def data_loader_py(train_filename, val_filename, batch_size, main_device):
   train = DataLoader(nnue_bin_dataset.NNUEBinData(train_filename), batch_size=batch_size, shuffle=True, num_workers=4)
   val = DataLoader(nnue_bin_dataset.NNUEBinData(val_filename), batch_size=32)
   return train, val
@@ -74,19 +74,22 @@ def main():
     print('limiting torch to {} threads.'.format(args.threads))
     t_set_num_threads(args.threads)
 
-  if args.py_data:
-    print('Using python data loader')
-    train, val = data_loader_py(args.train, args.val, batch_size)
-  else:
-    print('Using c++ data loader')
-    train, val = data_loader_cc(args.train, args.val, features_name, args.num_workers, batch_size, args.smart_fen_skipping)
-
   logdir = args.default_root_dir if args.default_root_dir else 'logs/'
   print('Using log dir {}'.format(logdir), flush=True)
 
   tb_logger = pl_loggers.TensorBoardLogger(logdir)
   checkpoint_callback = pl.callbacks.ModelCheckpoint(save_last=True)
   trainer = pl.Trainer.from_argparse_args(args, callbacks=[checkpoint_callback], logger=tb_logger)
+
+  main_device = trainer.root_device if trainer.root_gpu is None else 'cuda:' + str(trainer.root_gpu)
+
+  if args.py_data:
+    print('Using python data loader')
+    train, val = data_loader_py(args.train, args.val, batch_size, main_device)
+  else:
+    print('Using c++ data loader')
+    train, val = data_loader_cc(args.train, args.val, features_name, args.num_workers, batch_size, args.smart_fen_skipping, main_device)
+
   trainer.fit(nnue, train, val)
 
 if __name__ == '__main__':


### PR DESCRIPTION
If nothing significant changed this has the same effect as the previous draft:
vondele's tests
```
master: 634fd18a5617ded20e6e187336a28cc4084741a
18.54it/s  76% load

ensure_coalesced_2:
python train.py --smart-fen-skipping --batch-size 16384 --threads 8 --num-workers 4 --gpus "0,"
25.6 it/s
```

@vondele could you please verify that this is still better?