### PR TITLE
Only instantiate a single rng per thread. More laziness in skipPredicate.

### DIFF
--- a/lib/nnue_training_data_formats.h
+++ b/lib/nnue_training_data_formats.h
@@ -46,6 +46,8 @@ THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <mutex>
 #include <random>
 
+#include "rng.h"
+
 #if (defined(_MSC_VER) || defined(__INTEL_COMPILER)) && !defined(__clang__)
 #include <intrin.h>
 #endif
@@ -7579,8 +7581,8 @@ namespace binpack
                     if (!m_localBuffer.empty())
                     {
                         // now shuffle the local buffer
-			static thread_local std::mt19937 g(std::random_device{}());
-			std::shuffle(m_localBuffer.begin(), m_localBuffer.end(), g);
+                        auto& prng = rng::get_thread_local_rng();
+                        std::shuffle(m_localBuffer.begin(), m_localBuffer.end(), prng);
 
                         std::unique_lock lock(m_waitingBufferMutex);
                         m_waitingBufferEmpty.wait(lock, [this]() { return m_waitingBuffer.empty() || m_stopFlag.load(); });

--- a/lib/rng.h
+++ b/lib/rng.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <random>
+
+namespace rng
+{
+    inline auto& get_thread_local_rng()
+    {
+        static thread_local std::mt19937_64 s_rng(std::random_device{}());
+        return s_rng;
+    }
+}


### PR DESCRIPTION
This should be non-function apart from the rng change. This ensures only one rng per thread is created. Also the skipPredicate doesn't instantiate variables related to random skipping if it's not used.