### PR TITLE
A better abstraction for features on the python side.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ python train.py --resume_from_checkpoint <path> ...
 ```
 python train.py --gpus 1 ...
 ```
-
-## Enable factorizer
+## Feature set selection
+By default the trainer uses a factorized HalfKP feature set (named "HalfKP^")
+If you wish to change the feature set used then you can use the `--features=NAME` option. For the list of available features see `--help`
+The default is:
 ```
-python train.py --enable-factorizer ...
+python train.py ... --features="HalfKP^"
 ```
 
 # Export a network

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,15 @@
+# Features
+
+This doc is pretty much a copy-paste from [here](https://github.com/glinscott/nnue-pytorch/pull/30)
+
+A feature transformer is defined over a `feature_set`. A `feature_set` is a list of `feature_block`s. Each `feature_block` contains a name, hash, num_real_features, num_virtual_features, num_features, and knows some stuff about how to manipulate its indices. The number of real features and virtual features is used to distinguish factorizers, because they have to be handled differently on serialization to .nnue. A `feature_block` consists of `factors` which are an `OrderedDict` of `(str, int)` pairs where the first is the name of the factor and the second is its size. The first factor is assumed to be real, all the following ones are assumed to be virtual. `feature_set` concatenates these blocks and exposes similar operations. A `feature_block` knows how to coalesce its feature to real features. A `feature_block` is identified by it's name, for example `HalfKP` is a block, as is `HalfKP^` which denotes a factorized `HalfKP` (this is just a convention, but is strict and is used in some places for conversion ability discovery). A `feature_set` name is `'+'.join(...)` of names of its blocks.
+
+From now on the feature set used for learning and serialization/deserialization has to be specified explicitly as a program argument. The new argument `--features=...` takes a name of the feature set. For example `--features="HalfKP^"` or `--features="HalfKP"` or some imaginary `--features="HalfKP^+FancyFeatures+MoreFancyFeatures^"`. This argument is present in both train.py and serialize.py.
+
+The current semantics are as follows:
+
+1. When training a new net from scratch - `--features` specifies the feature set to use for learning. The feature transformer weights are initialized normally for the real features and zero initialized for the virtual features.
+2. When resuming training from a .pt model - `--features` specifies the feature set to use for learning. If the feature set specified doesn't match the feature set from the .pt model a conversion is attempted. Right now only a conversion of feature set with a single block from non-factorized to factorized is supported. The factorized block must have the non-factorized features as the first factor. The virtual feature weights are initialized to zero.
+3. When converting .ckpt to .nnue - `--features` specifies the features as stored in the .ckpt file. The user must pass the correct feature set through `--features` because it can't be inferred from the .ckpt. If the features from `--features` and the saved model don't match it'll likely stack trace on some dimension mismatch.
+4. When converting .pt to .nnue - `--features` is ignored, the `feature_set` from the saved model is used, the weights are coalesced when writing the .nnue file.
+5. When converting .nnue to .pt - `--features` specifies the features in the .nnue file. The resulting .pt model has the same feature_set. Note that when resuming training this model can be converted to a compatible feature_set, see point 2.

--- a/feature_block.py
+++ b/feature_block.py
@@ -4,6 +4,49 @@ def _get_main_factor_name(full_name):
     return full_name.replace('^', '')
 
 class FeatureBlock:
+    '''
+    This is the base class for all the network input features.
+    All features must inherit from this class.
+    It abstracts a named set of features in a way that
+    allows seamless introduction of factorizers.
+
+    For example a set of HalfKP features is a subclass of this class, and
+    so is the HalfKP^ feature set (where "^" denotes that it's factorized).
+
+    There are 3 fundamental things about a feature block which it needs for construction:
+        - name - whatever, just please use ascii. Also we'd like "^" to be reserved to
+                 denote that the block is a factorized version of some other block.
+        - hash - a 32 bit unsigned integer, as defined in the original nodchip trainer
+        - factors - the ordered list of named "festure subblocks". If there's more than one
+                    it's assumed that it's a factorized feature block.
+
+    More about factors, because it's the fundamental building block.
+    A block can have just one factor, like HalfKP, but sometimes it's possible to
+    factorize some features further. Ideally we don't want to have multiple
+    features talking about the same thing when the net is actually used for play,
+    because it's wasteful, but it's helpful during training because it makes it
+    easier to generalize over similar positions. This is for example utilized by HalfKP^,
+    which defines 3 factors: HalfKP, HalfK, and P.
+    Factors are passed to the constructor as an OrderedDict from string to the number of dimensions.
+    The first factor is the "real" factor (or "main" factor), one that is supposed to be used for play.
+    The following factors (if any) are the "virtual" factors, and are only used for training.
+    Based on these factors and their dimensions FeatureBlock defines 3 values:
+        - num_real_features - the number of unfactorized features that the resulting net will use in play
+        - num_virtual_features - the number of additional features used for learning
+                                 that will be coalesced when converting to .nnue
+        - num_features - the total number of features defined by the factors.
+                         should num_real_features + num_virtual_features
+
+    FeatureBlock provides default method implementations that abstract away the
+    factorized/unfactorized nature of the feature block. These methods are described in
+    their own docstrings.
+
+    The only method that the superclass of FeatureBlock must define is
+    get_active_features (def get_active_features(self, board: chess.Board)),
+    which takes the board and returns the list of indices of the features
+    that are active for this board.
+    '''
+
     def __init__(self, name, hash, factors):
         if not isinstance(factors, OrderedDict):
             raise Exception('Factors must be an collections.OrderedDict')
@@ -18,9 +61,18 @@ class FeatureBlock:
     def get_main_factor_name(self):
         return _get_main_factor_name(self.name)
 
+    '''
+    This method represents the default factorizer. If your feature block
+    has multiple factors you need to override this method to return
+    a list of factors for a given feature.
+    '''
     def get_feature_factors(self, idx):
         return [idx]
 
+    '''
+    This method takes a string name of a factor and returns the offset of the
+    first feature in this factor when consulted with the sizes of the previous factors.
+    '''
     def get_factor_base_feature(self, name):
         offset = 0
         for n, s in self.factors.items():

--- a/feature_block.py
+++ b/feature_block.py
@@ -1,0 +1,31 @@
+from collections import OrderedDict
+
+def _get_main_factor_name(full_name):
+    return full_name.replace('^', '')
+
+class FeatureBlock:
+    def __init__(self, name, factors):
+        if not isinstance(factors, OrderedDict):
+            raise Exception('Factors must be an collections.OrderedDict')
+
+        self.name = name
+        self.factors = factors
+        self.num_real_features = factors[_get_main_factor_name(name)]
+        self.num_features = sum(v for n, v in factors.items())
+        self.num_virtual_features = self.num_features - self.num_real_features
+
+    def get_main_factor_name(self):
+        return _get_main_factor_name(self.name)
+
+    def get_feature_factors(self, idx):
+        return [idx]
+
+    def get_factor_base_feature(self, name):
+        offset = 0
+        for n, s in self.factors.items():
+            if n == name:
+                return offset
+
+            offset += s
+
+        raise Exception('No factor named {} in {}'.format(name, self.name))

--- a/feature_block.py
+++ b/feature_block.py
@@ -4,11 +4,12 @@ def _get_main_factor_name(full_name):
     return full_name.replace('^', '')
 
 class FeatureBlock:
-    def __init__(self, name, factors):
+    def __init__(self, name, hash, factors):
         if not isinstance(factors, OrderedDict):
             raise Exception('Factors must be an collections.OrderedDict')
 
         self.name = name
+        self.hash = hash
         self.factors = factors
         self.num_real_features = factors[_get_main_factor_name(name)]
         self.num_features = sum(v for n, v in factors.items())

--- a/feature_set.py
+++ b/feature_set.py
@@ -1,0 +1,46 @@
+from collections import OrderedDict
+from feature_block import *
+
+class FeatureSet:
+    def __init__(self, features):
+        for feature in features:
+            if not isinstance(feature, FeatureBlock):
+                raise Exception('All features must subclass FeatureBlock')
+
+        self.features = features
+        self.name = '+'.join(feature.name for feature in features)
+        self.num_real_features = sum(feature.num_real_features for feature in features)
+        self.num_virtual_features = sum(feature.num_virtual_features for feature in features)
+        self.num_features = sum(feature.num_features for feature in features)
+
+    def get_virtual_feature_ranges(self):
+        ranges = []
+        offset = 0
+        for feature in self.features:
+            if feature.num_virtual_features:
+                ranges.append((offset + feature.num_real_features, offset + feature.num_features))
+            offset += feature.num_features
+
+        return ranges
+
+    def get_active_features(self, board):
+        w = []
+        b = []
+
+        offset = 0
+        for feature in self.features:
+            w_local, b_local = feature.get_active_features(board)
+            w += [i + offset for i in w_local]
+            b += [i + offset for i in b_local]
+            offset += feature.num_features
+
+        return w, b
+
+    def get_feature_factors(self, idx):
+        offset = 0
+        for feature in self.features:
+            if idx < offset + feature.num_real_features:
+                return [offset + i for i in feature.get_feature_factors(idx - offset)]
+            offset += feature.num_features
+
+        raise Exception('No feature block to factorize {}'.format(idx))

--- a/feature_set.py
+++ b/feature_set.py
@@ -9,6 +9,14 @@ def _calculate_features_hash(features):
     return features[0].hash ^ (tail_hash << 1) ^ (tail_hash >> 1) & 0xffffffff
 
 class FeatureSet:
+    '''
+    A feature set is nothing more than a list of named FeatureBlocks.
+    It itself functions similarily to a feature block, but we don't want to be
+    explicit about it as we don't want it to be used as a building block for other
+    feature sets. You can think of this class as a composite, but not the full extent.
+    It is basically a concatenation of feature blocks.
+    '''
+
     def __init__(self, features):
         for feature in features:
             if not isinstance(feature, FeatureBlock):
@@ -21,6 +29,12 @@ class FeatureSet:
         self.num_virtual_features = sum(feature.num_virtual_features for feature in features)
         self.num_features = sum(feature.num_features for feature in features)
 
+    '''
+    This method returns the feature ranges for the virtual factors of the
+    underlying feature blocks. This is useful to know during initialization,
+    when we want to zero initialize the virtual feature weights, but give some other
+    values to the real feature weights.
+    '''
     def get_virtual_feature_ranges(self):
         ranges = []
         offset = 0
@@ -31,6 +45,12 @@ class FeatureSet:
 
         return ranges
 
+    '''
+    This method goes over all of the feature blocks and gathers the active features.
+    Each block has its own index space assigned so the features from two different
+    blocks will never have the same index here. Basically the thing you would expect
+    to happen after concatenating many feature blocks.
+    '''
     def get_active_features(self, board):
         w = []
         b = []
@@ -44,6 +64,11 @@ class FeatureSet:
 
         return w, b
 
+    '''
+    This method takes a feature idx and looks for the block that owns it.
+    If it found the block it asks it to factorize the index, otherwise
+    it throws and Exception. The idx must refer to a real feature.
+    '''
     def get_feature_factors(self, idx):
         offset = 0
         for feature in self.features:
@@ -53,6 +78,16 @@ class FeatureSet:
 
         raise Exception('No feature block to factorize {}'.format(idx))
 
+    '''
+    This method does what get_feature_factors does but for all
+    valid features at the same time. It returns a list of length
+    self.num_real_features with ith element being a list of factors
+    of the ith feature.
+    This method is technically redundant but it allows to perform the operation
+    slightly faster when there's many feature blocks. It might be worth
+    to add a similar method to the FeatureBlock itself - to make it faster
+    for feature blocks with many factors.
+    '''
     def get_virtual_to_real_features_gather_indices(self):
         indices = []
         real_offset = 0

--- a/feature_set.py
+++ b/feature_set.py
@@ -44,3 +44,15 @@ class FeatureSet:
             offset += feature.num_features
 
         raise Exception('No feature block to factorize {}'.format(idx))
+
+    def get_virtual_to_real_features_gather_indices(self):
+        indices = []
+        real_offset = 0
+        offset = 0
+        for feature in self.features:
+            for i_real in range(feature.num_real_features):
+                i_fact = feature.get_feature_factors(i_real)
+                indices.append([offset + i for i in i_fact])
+            real_offset += feature.num_real_features
+            offset += feature.num_features
+        return indices

--- a/feature_set.py
+++ b/feature_set.py
@@ -1,6 +1,13 @@
 from collections import OrderedDict
 from feature_block import *
 
+def _calculate_features_hash(features):
+    if len(features) == 1:
+        return features[0].hash
+
+    tail_hash = calculate_features_hash(features[1:])
+    return features[0].hash ^ (tail_hash << 1) ^ (tail_hash >> 1) & 0xffffffff
+
 class FeatureSet:
     def __init__(self, features):
         for feature in features:
@@ -8,6 +15,7 @@ class FeatureSet:
                 raise Exception('All features must subclass FeatureBlock')
 
         self.features = features
+        self.hash = _calculate_features_hash(features)
         self.name = '+'.join(feature.name for feature in features)
         self.num_real_features = sum(feature.num_real_features for feature in features)
         self.num_virtual_features = sum(feature.num_virtual_features for feature in features)

--- a/features.py
+++ b/features.py
@@ -1,6 +1,8 @@
 from feature_block import *
 from feature_set import *
 
+import argparse
+
 import halfkp
 
 _feature_blocks_by_name = dict()
@@ -25,3 +27,6 @@ def get_feature_set_from_name(name):
 
 def get_available_feature_blocks_names():
     return list(iter(_feature_blocks_by_name))
+
+def add_argparse_args(parser):
+    parser.add_argument("--features", dest='features', help="The feature set to use. Can be a union of feature blocks (for example P+HalfKP). \"^\" denotes a factorized block. Currently available feature blocks are: " + ', '.join(get_available_feature_blocks_names()))

--- a/features.py
+++ b/features.py
@@ -3,9 +3,16 @@ from feature_set import *
 
 import argparse
 
+'''
+Each module that defines feature blocks must be imported here and
+added to the _feature_modules list. Each such module must define a
+function `get_feature_block_clss` at module scope that returns the list
+of feature block classes in that module.
+'''
 import halfkp
 
 _feature_modules = [halfkp]
+
 _feature_blocks_by_name = dict()
 
 def _add_feature_block(feature_block_cls):

--- a/features.py
+++ b/features.py
@@ -1,0 +1,27 @@
+from feature_block import *
+from feature_set import *
+
+import halfkp
+
+_feature_blocks_by_name = dict()
+
+def _add_feature_block(feature_block_cls):
+    feature_block = feature_block_cls()
+    _feature_blocks_by_name[feature_block.name] = feature_block
+
+_add_feature_block(halfkp.Features)
+_add_feature_block(halfkp.FactorizedFeatures)
+
+def get_feature_block_from_name(name):
+    return _feature_blocks_by_name[name]
+
+def get_feature_blocks_from_names(names):
+    return [_feature_blocks_by_name[name] for name in names]
+
+def get_feature_set_from_name(name):
+    feature_block_names = name.split('+')
+    blocks = get_feature_blocks_from_names(feature_block_names)
+    return FeatureSet(blocks)
+
+def get_available_feature_blocks_names():
+    return list(iter(_feature_blocks_by_name))

--- a/features.py
+++ b/features.py
@@ -5,16 +5,17 @@ import argparse
 
 import halfkp
 
+_feature_modules = [halfkp]
 _feature_blocks_by_name = dict()
 
 def _add_feature_block(feature_block_cls):
     feature_block = feature_block_cls()
     _feature_blocks_by_name[feature_block.name] = feature_block
-    return feature_block
 
-_add_feature_block(halfkp.Features)
-_default_feature_block = _add_feature_block(halfkp.FactorizedFeatures)
-_default_feature_set_name = _default_feature_block.name
+def _add_features_blocks_from_module(module):
+    feature_block_clss = module.get_feature_block_clss()
+    for feature_block_cls in feature_block_clss:
+        _add_feature_block(feature_block_cls)
 
 def get_feature_block_from_name(name):
     return _feature_blocks_by_name[name]
@@ -31,4 +32,11 @@ def get_available_feature_blocks_names():
     return list(iter(_feature_blocks_by_name))
 
 def add_argparse_args(parser):
+    _default_feature_set_name = 'HalfKP^'
     parser.add_argument("--features", dest='features', default=_default_feature_set_name, help="The feature set to use. Can be a union of feature blocks (for example P+HalfKP). \"^\" denotes a factorized block. Currently available feature blocks are: " + ', '.join(get_available_feature_blocks_names()))
+
+def _init():
+    for module in _feature_modules:
+        _add_features_blocks_from_module(module)
+
+_init()

--- a/features.py
+++ b/features.py
@@ -10,9 +10,11 @@ _feature_blocks_by_name = dict()
 def _add_feature_block(feature_block_cls):
     feature_block = feature_block_cls()
     _feature_blocks_by_name[feature_block.name] = feature_block
+    return feature_block
 
 _add_feature_block(halfkp.Features)
-_add_feature_block(halfkp.FactorizedFeatures)
+_default_feature_block = _add_feature_block(halfkp.FactorizedFeatures)
+_default_feature_set_name = _default_feature_block.name
 
 def get_feature_block_from_name(name):
     return _feature_blocks_by_name[name]
@@ -29,4 +31,4 @@ def get_available_feature_blocks_names():
     return list(iter(_feature_blocks_by_name))
 
 def add_argparse_args(parser):
-    parser.add_argument("--features", dest='features', help="The feature set to use. Can be a union of feature blocks (for example P+HalfKP). \"^\" denotes a factorized block. Currently available feature blocks are: " + ', '.join(get_available_feature_blocks_names()))
+    parser.add_argument("--features", dest='features', default=_default_feature_set_name, help="The feature set to use. Can be a union of feature blocks (for example P+HalfKP). \"^\" denotes a factorized block. Currently available feature blocks are: " + ', '.join(get_available_feature_blocks_names()))

--- a/halfkp.py
+++ b/halfkp.py
@@ -1,5 +1,8 @@
 import chess
 import torch
+import feature_block
+from collections import OrderedDict
+from feature_block import *
 
 NUM_SQ = 64
 NUM_PT = 10
@@ -12,58 +15,32 @@ def halfkp_idx(is_white_pov: bool, king_sq: int, sq: int, p: chess.Piece):
   p_idx = (p.piece_type - 1) * 2 + (p.color != is_white_pov)
   return 1 + orient(is_white_pov, sq) + p_idx * NUM_SQ + king_sq * NUM_PLANES
 
-class Features:
-  name = 'HalfKP'
-  inputs = NUM_PLANES * NUM_SQ # 41024
+class Features(FeatureBlock):
+  def __init__(self):
+    super(Features, self).__init__('HalfKP', OrderedDict([('HalfKP', NUM_PLANES * NUM_SQ)]))
 
-  def get_indices(self, board: chess.Board):
-    def piece_indices(turn):
+  def get_active_features(self, board: chess.Board):
+    def piece_features(turn):
       indices = torch.zeros(inputs)
       for sq, p in board.piece_map().items():
         if p.piece_type == chess.KING:
           continue
         indices[halfkp_idx(turn, orient(turn, board.king(turn)), sq, p)] = 1.0
       return indices
-    return (piece_indices(chess.WHITE), piece_indices(chess.BLACK))
+    return (piece_features(chess.WHITE), piece_features(chess.BLACK))
 
-# Factors are used by the trainer to share weights between common elements of
-# the features.
-class Factorizer:
-  name = 'HalfKPFactorized'
-  factors = {
-    'kings': 64,
-    'pieces': 640,
-  }
-  inputs = sum(factors.values())
+class FactorizedFeatures(FeatureBlock):
+  def __init__(self):
+    super(FactorizedFeatures, self).__init__('HalfKP^', OrderedDict([('HalfKP', NUM_PLANES * NUM_SQ), ('HalfK', NUM_SQ), ('P', NUM_SQ * 10 )]))
 
-  def get_indices(self, board: chess.Board):
+  def get_active_features(self, board: chess.Board):
     raise Exception('Not supported yet, you must use the c++ data loader for factorizer support during training')
 
-  def coalesce_weights(self, weights):
-    # incoming weights are in [256][INPUTS]
-    print('factorized shape:', weights.shape)
-    k_base = 41024
-    p_base = k_base + 64
-    result = []
-    # Goal here is to add together all the weights that would be active for the
-    # given piece and king position in the halfkp inputs.
-    for i in range(k_base):
-      k_idx = i // NUM_PLANES
-      p_idx = i % NUM_PLANES
-      w = weights.narrow(1, i, 1).clone()
-      # King factorization.  Note that this is trickier than it appears.  The
-      # weights for the king factor in the training set is equal to the number
-      # of active base features.  This means that we (roughly) average the
-      # number of pieces across the training dataset, and "bake" that in here.
-      # If the king feature is treated as a one-hot encoding, you'd have to
-      # divide by the average number of pieces in the dataset here (eg. divide
-      # by 20).
-      w = w + weights.narrow(1, k_base + k_idx, 1)
-      # Piece factorization.  Note that p_idx 0 is not used by SF currently,
-      # and the factorized pieces don't do the equivalent mapping, so that's
-      # why we ignore it here.
-      if p_idx > 0:
-        w = w + weights.narrow(1, p_base + p_idx - 1, 1)
-      result.append(w)
-    return torch.cat(result, dim=1)
+  def get_feature_factors(self, idx):
+    if idx >= self.num_real_features:
+      raise Exception('Feature must be real')
 
+    k_idx = i // NUM_PLANES
+    p_idx = i % NUM_PLANES
+
+    return [idx, get_factor_base_feature('HalfK') + k_idx, get_factor_base_feature('P') + p_idx]

--- a/halfkp.py
+++ b/halfkp.py
@@ -40,7 +40,7 @@ class FactorizedFeatures(FeatureBlock):
     if idx >= self.num_real_features:
       raise Exception('Feature must be real')
 
-    k_idx = i // NUM_PLANES
-    p_idx = i % NUM_PLANES
+    k_idx = idx // NUM_PLANES
+    p_idx = idx % NUM_PLANES - 1
 
-    return [idx, get_factor_base_feature('HalfK') + k_idx, get_factor_base_feature('P') + p_idx]
+    return [idx, self.get_factor_base_feature('HalfK') + k_idx, self.get_factor_base_feature('P') + p_idx]

--- a/halfkp.py
+++ b/halfkp.py
@@ -44,3 +44,6 @@ class FactorizedFeatures(FeatureBlock):
     p_idx = idx % NUM_PLANES - 1
 
     return [idx, self.get_factor_base_feature('HalfK') + k_idx, self.get_factor_base_feature('P') + p_idx]
+
+def get_feature_block_clss():
+  return [Features, FactorizedFeatures]

--- a/halfkp.py
+++ b/halfkp.py
@@ -17,7 +17,7 @@ def halfkp_idx(is_white_pov: bool, king_sq: int, sq: int, p: chess.Piece):
 
 class Features(FeatureBlock):
   def __init__(self):
-    super(Features, self).__init__('HalfKP', OrderedDict([('HalfKP', NUM_PLANES * NUM_SQ)]))
+    super(Features, self).__init__('HalfKP', 0x5d69d7b8, OrderedDict([('HalfKP', NUM_PLANES * NUM_SQ)]))
 
   def get_active_features(self, board: chess.Board):
     def piece_features(turn):
@@ -31,7 +31,7 @@ class Features(FeatureBlock):
 
 class FactorizedFeatures(FeatureBlock):
   def __init__(self):
-    super(FactorizedFeatures, self).__init__('HalfKP^', OrderedDict([('HalfKP', NUM_PLANES * NUM_SQ), ('HalfK', NUM_SQ), ('P', NUM_SQ * 10 )]))
+    super(FactorizedFeatures, self).__init__('HalfKP^', 0x5d69d7b8, OrderedDict([('HalfKP', NUM_PLANES * NUM_SQ), ('HalfK', NUM_SQ), ('P', NUM_SQ * 10 )]))
 
   def get_active_features(self, board: chess.Board):
     raise Exception('Not supported yet, you must use the c++ data loader for factorizer support during training')

--- a/halfkp.py
+++ b/halfkp.py
@@ -45,5 +45,8 @@ class FactorizedFeatures(FeatureBlock):
 
     return [idx, self.get_factor_base_feature('HalfK') + k_idx, self.get_factor_base_feature('P') + p_idx]
 
+'''
+This is used by the features module for discovery of feature blocks.
+'''
 def get_feature_block_clss():
   return [Features, FactorizedFeatures]

--- a/model.py
+++ b/model.py
@@ -1,5 +1,4 @@
 import chess
-import halfkp
 import ranger
 import torch
 from torch import nn
@@ -20,31 +19,22 @@ class NNUE(pl.LightningModule):
 
   It is not ideal for training a Pytorch quantized model directly.
   """
-  def __init__(self, feature_set=halfkp.Features(), factorizer=halfkp.Factorizer(), lambda_=1.0):
+  def __init__(self, feature_set, lambda_=1.0):
     super(NNUE, self).__init__()
+    self.input = nn.Linear(feature_set.num_features, L1)
     self.feature_set = feature_set
-    self.change_factorizer(factorizer)
     self.l1 = nn.Linear(2 * L1, L2)
     self.l2 = nn.Linear(L2, L3)
     self.output = nn.Linear(L3, 1)
     self.lambda_ = lambda_
 
-  # Call to change the factorizer.  Will reset the input weights to match the expected shape.
-  def change_factorizer(self, factorizer):
-    self.factorizer = factorizer
-    num_inputs = self.feature_set.inputs
-    if self.factorizer is not None:
-      num_inputs += self.factorizer.inputs
-    # Don't reinitialize the weights if they've already been set.
-    if not hasattr(self, 'input'):
-      self.input = nn.Linear(num_inputs, L1)
+    self._zero_virtual_feature_weights()
 
-    if self.factorizer is not None:
-      # Zero out the weights/biases for the factorized features
-      # Weights stored as [256][41024]
-      weights = self.input.weight.narrow(1, 0, self.feature_set.inputs)
-      weights = torch.cat((weights, torch.zeros(L1, self.factorizer.inputs)), dim=1)
-      self.input.weight = nn.Parameter(weights)
+  def _zero_virtual_feature_weights(self):
+    weights = self.input.weight
+    for a, b in self.feature_set.get_virtual_feature_ranges():
+      weights[a:b, :] = 0.0
+    self.input.weight = nn.Parameter(weights)
 
   def forward(self, us, them, w_in, b_in):
     w = self.input(w_in)

--- a/serialize.py
+++ b/serialize.py
@@ -31,7 +31,7 @@ class NNUEWriter():
     self.buf = bytearray()
 
     self.write_header()
-    self.int32(0x5d69d7b8) # Feature transformer hash
+    self.int32(model.feature_set.hash) # Feature transformer hash
     self.write_feature_transformer(model)
     self.int32(0x63337156) # FC layers hash
     self.write_fc_layer(model.l1)
@@ -104,7 +104,7 @@ class NNUEReader():
     self.model = M.NNUE(feature_set)
 
     self.read_header()
-    self.read_int32(0x5d69d7b8) # Feature transformer hash
+    self.read_int32(feature_set.hash) # Feature transformer hash
     self.read_feature_transformer(self.model.input)
     self.read_int32(0x63337156) # FC layers hash
     self.read_fc_layer(self.model.l1)

--- a/serialize.py
+++ b/serialize.py
@@ -1,5 +1,5 @@
 import argparse
-import halfkp
+import features
 import math
 import model as M
 import numpy
@@ -32,7 +32,7 @@ class NNUEWriter():
 
     self.write_header()
     self.int32(0x5d69d7b8) # Feature transformer hash
-    self.write_feature_transformer(model.factorizer, model.input)
+    self.write_feature_transformer(model)
     self.int32(0x63337156) # FC layers hash
     self.write_fc_layer(model.l1)
     self.write_fc_layer(model.l2)
@@ -47,17 +47,25 @@ class NNUEWriter():
     self.int32(len(description)) # Network definition
     self.buf.extend(description)
 
-  def write_feature_transformer(self, factorizer, layer):
+  def coalesce_ft_weights(self, model, layer):
+    weight = layer.weight.data
+    indices = model.feature_set.get_virtual_to_real_features_gather_indices()
+    weight_coalesced = weight.new_zeros((weight.shape[0], model.feature_set.num_real_features))
+    for i_real, is_virtual in enumerate(indices):
+      weight_coalesced[:, i_real] = sum(weight[:, i_virtual] for i_virtual in is_virtual)
+
+    return weight_coalesced
+
+  def write_feature_transformer(self, model):
     # int16 bias = round(x * 127)
     # int16 weight = round(x * 127)
+    layer = model.input
     bias = layer.bias.data
     bias = bias.mul(127).round().to(torch.int16)
     ascii_hist('ft bias:', bias.numpy())
     self.buf.extend(bias.flatten().numpy().tobytes())
 
-    weight = layer.weight.data
-    if factorizer is not None:
-      weight = factorizer.coalesce_weights(weight)
+    weight = self.coalesce_ft_weights(model, layer)
     weight = weight.mul(127).round().to(torch.int16)
     ascii_hist('ft weight:', weight.numpy())
     # weights stored as [41024][256], so we need to transpose the pytorch [256][41024]
@@ -90,9 +98,10 @@ class NNUEWriter():
     self.buf.extend(struct.pack("<i", v))
 
 class NNUEReader():
-  def __init__(self, f):
+  def __init__(self, f, feature_set):
     self.f = f
-    self.model = M.NNUE(factorizer=None)
+    self.feature_set = feature_set
+    self.model = M.NNUE(feature_set)
 
     self.read_header()
     self.read_int32(0x5d69d7b8) # Feature transformer hash
@@ -143,7 +152,10 @@ def main():
   parser = argparse.ArgumentParser(description="Converts files between ckpt and nnue format.")
   parser.add_argument("source", help="Source file (can be .ckpt, .pt or .nnue)")
   parser.add_argument("target", help="Target file (can be .pt or .nnue)")
+  features.add_argparse_args(parser)
   args = parser.parse_args()
+
+  feature_set = features.get_feature_set_from_name(args.features)
 
   print('Converting %s to %s' % (args.source, args.target))
 
@@ -153,14 +165,7 @@ def main():
     if args.source.endswith(".pt"):
       nnue = torch.load(args.source)
     else:
-      # This try/catch is not ideal, but we don't know if we are converting
-      # a factorized checkpoint, or an unfactorized one.
-      try:
-        # First try with defaults (factorizer on).
-        nnue = M.NNUE.load_from_checkpoint(args.source)
-      except:
-        # If that fails, then try with factorizer disaabled.
-        nnue = M.NNUE.load_from_checkpoint(args.source, factorizer=None)
+      nnue = M.NNUE.load_from_checkpoint(args.source, feature_set=feature_set)
     nnue.eval()
     writer = NNUEWriter(nnue)
     with open(args.target, 'wb') as f:
@@ -169,7 +174,7 @@ def main():
     if not args.target.endswith(".pt"):
       raise Exception("Target file must end with .pt")
     with open(args.source, 'rb') as f:
-      reader = NNUEReader(f)
+      reader = NNUEReader(f, feature_set)
     torch.save(reader.model, args.target)
   else:
     raise Exception('Invalid filetypes: ' + str(args))

--- a/train.py
+++ b/train.py
@@ -44,7 +44,7 @@ def main():
   parser.add_argument("--random-fen-skipping", default=0, type=int, dest='random_fen_skipping', help="skip fens randomly on average random_fen_skipping before using one.")
   parser.add_argument("--enable-factorizer", dest='enable_factorizer', action='store_true', help="Enables using the factorizer for training.")
   parser.add_argument("--resume-from-model", dest='resume_from_model', help="Initializes training using the weights from the given .pt model")
-  parser.add_argument("--features", dest='features', help="The feature set to use. Can be a union of feature blocks (for example P+HalfKP). \"^\" denotes a factorized block. Currently available feature blocks are: " + ', '.join(features.get_available_feature_blocks_names()))
+  features.add_argparse_args(parser)
   args = parser.parse_args()
 
   feature_set = features.get_feature_set_from_name(args.features)

--- a/train.py
+++ b/train.py
@@ -53,6 +53,7 @@ def main():
     nnue = M.NNUE(feature_set=feature_set, lambda_=args.lambda_)
   else:
     nnue = torch.load(args.resume_from_model)
+    nnue.set_feature_set(feature_set)
     nnue.lambda_ = args.lambda_
 
   print("Feature set: {}".format(feature_set.name))

--- a/train.py
+++ b/train.py
@@ -42,7 +42,6 @@ def main():
   parser.add_argument("--seed", default=42, type=int, dest='seed', help="torch seed to use.")
   parser.add_argument("--smart-fen-skipping", action='store_true', dest='smart_fen_skipping', help="If enabled positions that are bad training targets will be skipped during loading. Default: False")
   parser.add_argument("--random-fen-skipping", default=0, type=int, dest='random_fen_skipping', help="skip fens randomly on average random_fen_skipping before using one.")
-  parser.add_argument("--enable-factorizer", dest='enable_factorizer', action='store_true', help="Enables using the factorizer for training.")
   parser.add_argument("--resume-from-model", dest='resume_from_model', help="Initializes training using the weights from the given .pt model")
   features.add_argparse_args(parser)
   args = parser.parse_args()

--- a/training_data_loader.cpp
+++ b/training_data_loader.cpp
@@ -414,7 +414,7 @@ extern "C" {
         {
             return new FeaturedBatchStream<FeatureSet<HalfKP>, SparseBatch>(concurrency, filename, batch_size, cyclic, skipPredicate);
         }
-        else if (feature_set == "HalfKPFactorized")
+        else if (feature_set == "HalfKP^")
         {
             return new FeaturedBatchStream<FeatureSet<HalfKPFactorized>, SparseBatch>(concurrency, filename, batch_size, cyclic, skipPredicate);
         }


### PR DESCRIPTION
This PR introduces a more robust and extensible abstraction for features (for now only on the python side).

A feature transformer is defined over a `feature_set`. A `feature_set` is a list of `feature_block`s. Each `feature_block` contains a name, hash, num_real_features, num_virtual_features, num_features, and knows some stuff about how to manipulate its indices. The number of real features and virtual features is used to distinguish factorizers, because they have to be handled differently on serialization to .nnue. A `feature_block` consists of `factors` which are an `OrderedDict` of `(str, int)` pairs where the first is the name of the factor and the second is its size. The first factor is assumed to be real, all the following ones are assumed to be virtual. `feature_set` concatenates these blocks and exposes similar operations. A `feature_block` knows how to coalesce its feature to real features. A `feature_block` is identified by it's name, for example `HalfKP` is a block, as is `HalfKP^` which denotes a factorized `HalfKP` (this is just a convention, but is strict and is used in some places for conversion ability discovery). A `feature_set` name is `'+'.join(...)` of names of its blocks.

From now on the feature set used for learning and serialization/deserialization has to be specified explicitly as a program argument. The new argument `--features=...` takes a name of the feature set. For example `--features="HalfKP^"` or `--features="HalfKP"` or some imaginary `--features="HalfKP^+FancyFeatures+MoreFancyFeatures^"`. This argument is present in both train.py and serialize.py.

The current semantics are as follows:
1. When training a new net from scratch - `--features` specifies the feature set to use for learning. The feature transformer weights are initialized normally for the real features and zero initialized for the virtual features.
2. When resuming training from a .pt model - `--features` specifies the feature set to use for learning. If the feature set specified doesn't match the feature set from the .pt model a conversion is attempted. Right now only a conversion of feature set with a single block from non-factorized to factorized is supported. The factorized block must have the non-factorized features as the first factor. The virtual feature weights are initialized to zero.
3. When converting .ckpt to .nnue - `--features` specifies the features as stored in the .ckpt file. `load_from_checkpoint` doesn't correctly call the constructor with correct feature_set. I have not explored this and it may be improved, I don't know exactly how this works. The weights are coalesced when writing the .nnue file.
4. When converting .pt to .nnue - `--features` is ignored, the `feature_set` from the saved model is used, the weights are coalesced when writing the .nnue file.
5. When converting .nnue to .pt - `--features` specifies the features in the .nnue file. The resulting .pt model has the same feature_set. Note that when resuming training this model can be converted to a compatible feature_set, see point 2.

Known defects:
- the description string for the net is not dependent on the feature set used. This is a minor issue because it's ignored when loading the net.