### PR TITLE
Add support for (flip) HalfKA features

### DIFF
--- a/features.py
+++ b/features.py
@@ -10,8 +10,9 @@ function `get_feature_block_clss` at module scope that returns the list
 of feature block classes in that module.
 '''
 import halfkp
+import halfka
 
-_feature_modules = [halfkp]
+_feature_modules = [halfkp, halfka]
 
 _feature_blocks_by_name = dict()
 

--- a/halfka.py
+++ b/halfka.py
@@ -17,7 +17,7 @@ def halfka_idx(is_white_pov: bool, king_sq: int, sq: int, p: chess.Piece):
 
 class Features(FeatureBlock):
   def __init__(self):
-    super(Features, self).__init__('HalfKA', 0x5f134cb9, OrderedDict([('HalfKA', NUM_PLANES * NUM_SQ)]))
+    super(Features, self).__init__('HalfKA', 0x5f134cb8, OrderedDict([('HalfKA', NUM_PLANES * NUM_SQ)]))
 
   def get_active_features(self, board: chess.Board):
     def piece_features(turn):
@@ -29,7 +29,7 @@ class Features(FeatureBlock):
 
 class FactorizedFeatures(FeatureBlock):
   def __init__(self):
-    super(FactorizedFeatures, self).__init__('HalfKA^', 0x5f134cb9, OrderedDict([('HalfKA', NUM_PLANES * NUM_SQ), ('A', NUM_SQ * NUM_PT)]))
+    super(FactorizedFeatures, self).__init__('HalfKA^', 0x5f134cb8, OrderedDict([('HalfKA', NUM_PLANES * NUM_SQ), ('A', NUM_SQ * NUM_PT)]))
 
   def get_active_features(self, board: chess.Board):
     raise Exception('Not supported yet, you must use the c++ data loader for factorizer support during training')

--- a/halfka.py
+++ b/halfka.py
@@ -1,0 +1,49 @@
+import chess
+import torch
+import feature_block
+from collections import OrderedDict
+from feature_block import *
+
+NUM_SQ = 64
+NUM_PT = 12
+NUM_PLANES = (NUM_SQ * NUM_PT + 1)
+
+def orient(is_white_pov: bool, sq: int):
+  return (56 * (not is_white_pov)) ^ sq
+
+def halfka_idx(is_white_pov: bool, king_sq: int, sq: int, p: chess.Piece):
+  p_idx = (p.piece_type - 1) * 2 + (p.color != is_white_pov)
+  return 1 + orient(is_white_pov, sq) + p_idx * NUM_SQ + king_sq * NUM_PLANES
+
+class Features(FeatureBlock):
+  def __init__(self):
+    super(Features, self).__init__('HalfKA', 0x5f134cb9, OrderedDict([('HalfKA', NUM_PLANES * NUM_SQ)]))
+
+  def get_active_features(self, board: chess.Board):
+    def piece_features(turn):
+      indices = torch.zeros(NUM_PLANES * NUM_SQ)
+      for sq, p in board.piece_map().items():
+        indices[halfka_idx(turn, orient(turn, board.king(turn)), sq, p)] = 1.0
+      return indices
+    return (piece_features(chess.WHITE), piece_features(chess.BLACK))
+
+class FactorizedFeatures(FeatureBlock):
+  def __init__(self):
+    super(FactorizedFeatures, self).__init__('HalfKA^', 0x5f134cb9, OrderedDict([('HalfKA', NUM_PLANES * NUM_SQ), ('A', NUM_SQ * NUM_PT)]))
+
+  def get_active_features(self, board: chess.Board):
+    raise Exception('Not supported yet, you must use the c++ data loader for factorizer support during training')
+
+  def get_feature_factors(self, idx):
+    if idx >= self.num_real_features:
+      raise Exception('Feature must be real')
+
+    a_idx = idx % NUM_PLANES - 1
+
+    return [idx, self.get_factor_base_feature('A') + a_idx]
+
+'''
+This is used by the features module for discovery of feature blocks.
+'''
+def get_feature_block_clss():
+  return [Features, FactorizedFeatures]

--- a/halfkp.py
+++ b/halfkp.py
@@ -17,7 +17,7 @@ def halfkp_idx(is_white_pov: bool, king_sq: int, sq: int, p: chess.Piece):
 
 class Features(FeatureBlock):
   def __init__(self):
-    super(Features, self).__init__('HalfKP', 0x5d69d7b8, OrderedDict([('HalfKP', NUM_PLANES * NUM_SQ)]))
+    super(Features, self).__init__('HalfKP', 0x5d69d5b8, OrderedDict([('HalfKP', NUM_PLANES * NUM_SQ)]))
 
   def get_active_features(self, board: chess.Board):
     def piece_features(turn):
@@ -31,7 +31,7 @@ class Features(FeatureBlock):
 
 class FactorizedFeatures(FeatureBlock):
   def __init__(self):
-    super(FactorizedFeatures, self).__init__('HalfKP^', 0x5d69d7b8, OrderedDict([('HalfKP', NUM_PLANES * NUM_SQ), ('HalfK', NUM_SQ), ('P', NUM_SQ * 10 )]))
+    super(FactorizedFeatures, self).__init__('HalfKP^', 0x5d69d5b8, OrderedDict([('HalfKP', NUM_PLANES * NUM_SQ), ('HalfK', NUM_SQ), ('P', NUM_SQ * 10 )]))
 
   def get_active_features(self, board: chess.Board):
     raise Exception('Not supported yet, you must use the c++ data loader for factorizer support during training')

--- a/serialize.py
+++ b/serialize.py
@@ -35,7 +35,7 @@ class NNUEWriter():
     self.buf = bytearray()
 
     self.write_header(model)
-    self.int32(model.feature_set.hash) # Feature transformer hash
+    self.int32(model.feature_set.hash ^ (M.L1*2)) # Feature transformer hash
     self.write_feature_transformer(model)
     self.int32(FC_HASH) # FC layers hash
     self.write_fc_layer(model.l1)
@@ -44,7 +44,7 @@ class NNUEWriter():
 
   def write_header(self, model):
     self.int32(VERSION) # version
-    self.int32(FC_HASH ^ model.feature_set.hash) # halfkp network hash
+    self.int32(FC_HASH ^ model.feature_set.hash ^ (M.L1*2)) # halfkp network hash
     description = b"Features=HalfKP(Friend)[41024->256x2],"
     description += b"Network=AffineTransform[1<-32](ClippedReLU[32](AffineTransform[32<-32]"
     description += b"(ClippedReLU[32](AffineTransform[32<-512](InputSlice[512(0:512)])))))"
@@ -108,7 +108,7 @@ class NNUEReader():
     self.model = M.NNUE(feature_set)
 
     self.read_header(feature_set)
-    self.read_int32(feature_set.hash) # Feature transformer hash
+    self.read_int32(feature_set.hash ^ (M.L1*2)) # Feature transformer hash
     self.read_feature_transformer(self.model.input)
     self.read_int32(FC_HASH) # FC layers hash
     self.read_fc_layer(self.model.l1)
@@ -117,7 +117,7 @@ class NNUEReader():
 
   def read_header(self, feature_set):
     self.read_int32(VERSION) # version
-    self.read_int32(FC_HASH ^ feature_set.hash) # halfkp network hash
+    self.read_int32(FC_HASH ^ feature_set.hash ^ (M.L1*2)) # halfkp network hash
     desc_len = self.read_int32() # Network definition
     description = self.f.read(desc_len)
 


### PR DESCRIPTION
This PR adds `HalfKA` and `HalfKA^` feature blocks.

The stockfish binary that can be used for playing (on nodchip because I couldn't be bothered with the official-stockfish): https://github.com/Sopel97/Stockfish/tree/flip_halfka

Note: This PR fixes the serialization and deserialization of the FT hash. Now the hash exposed by the feature class matches the hash in nodchip (previously it was ^512, which should be done later). This breaks .pt/.ckpt -> .nnue conversion of old models (but can be hacked by forcing model.feature_set in the code to be different, it just loads the old one from the checkpoint)