### PR TITLE
Add visualizer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,14 @@ Import an existing SF NNUE network to the pytorch network format.
 python serialize.py nn.nnue converted.pt
 ```
 
+# Visualize a network
+
+Visualize a network from either a checkpoint (`.ckpt`), a serialized model (`.pt`)
+or a SF NNUE file (`.nnue`).
+```
+python visualize.py nn.nnue
+```
+
 # Logging
 
 ```

--- a/visualize.py
+++ b/visualize.py
@@ -1,0 +1,121 @@
+import argparse
+import features
+import model as M
+import numpy as np
+import torch
+import matplotlib.pyplot as plt
+
+from serialize import NNUEReader
+
+
+class NNUEVisualizer():
+    def __init__(self, model):
+        self.model = model
+
+    def coalesce_ft_weights(self, model, layer):
+        weight = layer.weight.data
+        indices = model.feature_set.get_virtual_to_real_features_gather_indices()
+        weight_coalesced = weight.new_zeros(
+            (weight.shape[0], model.feature_set.num_real_features))
+        for i_real, is_virtual in enumerate(indices):
+            weight_coalesced[:, i_real] = sum(
+                weight[:, i_virtual] for i_virtual in is_virtual)
+
+        return weight_coalesced
+
+    def plot_feature_transformer(self, title):
+        # Coalesce weights and transform them to Numpy domain.
+        weights = self.coalesce_ft_weights(self.model, self.model.input)
+        weights = weights.transpose(0, 1).flatten().numpy()
+
+        hd = 256  # Output feature dimension.
+        numx = 32  # Number of output features per row.
+
+        # Derived/fixed constants.
+        numy = hd//numx
+        widthx = 128
+        widthy = 304
+        totalx = numx * widthx
+        totaly = numy * widthy
+        totaldim = totalx*totaly
+
+        # Generate image.
+        # [Thanks to https://github.com/hxim/Stockfish-Evaluation-Guide
+        # upon which the following code is based.]
+        img = np.zeros(totaldim)
+        for j in range(weights.size):
+            # Calculate piece and king placement.
+            pi = (j // hd - 1) % 641
+            ki = (j // hd - 1) // 641
+            piece = pi // 64
+            rank = (pi % 64) // 8
+
+            if (pi == 640 or (rank == 0 or rank == 7) and (piece == 0 or piece == 1)):
+                # Ignore unused weights for "Shogi piece drop" and pawns on first/last rank.
+                continue
+
+            kipos = [ki % 8, ki // 8]
+            pipos = [pi % 8, rank]
+            inpos = [(7-kipos[0])+pipos[0]*8,
+                     kipos[1]+(7-pipos[1])*8]
+            d = - 8 if piece < 2 else 48 + (piece // 2 - 1) * 64
+            jhd = j % hd
+            x = inpos[0] + widthx * ((jhd) % numx) + (piece % 2)*64
+            y = inpos[1] + d + widthy * (jhd // numx)
+            ii = x + y * totalx
+
+            img[ii] = weights[j]
+
+        # Plot image.
+        plt.matshow(np.abs(img.reshape((totaldim//totalx, totalx))),
+                    vmin=0, vmax=0.5)
+        plt.colorbar()
+
+        for i in range(numx):
+            plt.axvline(x=widthx*i-0.5, color='red')
+
+        for j in range(numy):
+            plt.axhline(y=widthy*j-0.5, color='red')
+
+        plt.xlim([0, totalx])
+        plt.ylim([totaly, 0])
+        plt.title(title)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Visualizes networks in ckpt, pt and nnue format.")
+    parser.add_argument(
+        "source", help="Source file (can be .ckpt, .pt or .nnue)")
+    features.add_argparse_args(parser)
+    args = parser.parse_args()
+
+    feature_set = features.get_feature_set_from_name(args.features)
+
+    print("Visualizing {}".format(args.source))
+
+    if args.source.endswith(".pt") or args.source.endswith(".ckpt"):
+        if args.source.endswith(".pt"):
+            nnue = torch.load(args.source)
+        else:
+            nnue = M.NNUE.load_from_checkpoint(
+                args.source, feature_set=feature_set)
+        nnue.eval()
+    elif args.source.endswith(".nnue"):
+        with open(args.source, 'rb') as f:
+            reader = NNUEReader(f, feature_set)
+        nnue = reader.model
+    else:
+        raise Exception("Invalid filetype: " + str(args))
+
+    from os.path import basename
+    bn = basename(args.source)
+
+    visualizer = NNUEVisualizer(nnue)
+    visualizer.plot_feature_transformer(
+        "abs(input weights) [{}]".format(bn))
+    plt.show()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This is a cleanup of the script in https://github.com/official-stockfish/Stockfish/issues/3274, extended to work on pytorch models (such that also checkpoints can be loaded).

At the moment, abs(input weights) is plotted (in the same style as the base script, but now normalized between 0 and 0.5).

Note that this is a "minimal working example". Please suggest if there is any need/wish to extend it with CLI arguments to e.g.

- Save plots directly to images (non-interactive mode for headless/automated use case).
- Control some parameters (saturation threshold that is now arbitrarily at 0.5; provide the option to plot non-abs values).
- Other useful plots?
- ...