### PR TITLE
Add stepLR scheduler, adjust default ranger betas

### DIFF
--- a/model.py
+++ b/model.py
@@ -127,5 +127,7 @@ class NNUE(pl.LightningModule):
     self.step_(batch, batch_idx, 'test_loss')
 
   def configure_optimizers(self):
-    optimizer = ranger.Ranger(self.parameters())
-    return optimizer
+    optimizer = ranger.Ranger(self.parameters(),betas=(.9, 0.999))
+    # Drop learning rate after 75 epochs
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=75)
+    return [optimizer], [scheduler]


### PR DESCRIPTION
yields best net so far.

https://tests.stockfishchess.org/tests/view/5fef930f6019e097de3eeb84

using gensfen data:

https://drive.google.com/file/d/1VlhnHL8f-20AXhGkILujnNXHwy9T-MQw/view?usp=sharing