### PR TITLE
Improved cmaps

### DIFF
--- a/visualize.py
+++ b/visualize.py
@@ -78,8 +78,9 @@ class NNUEVisualizer():
 
         # Plot image.
         plt.figure(figsize=(16, 9))
+        cmap = 'coolwarm' if vmin < 0 else 'viridis'
         plt.matshow(img.reshape((totaldim//totalx, totalx)),
-                    fignum=0, vmin=vmin, vmax=vmax, cmap='jet')
+                    fignum=0, vmin=vmin, vmax=vmax, cmap=cmap)
         plt.colorbar(fraction=0.046, pad=0.04)
 
         line_options = {'color': 'black', 'linewidth': 0.5}


### PR DESCRIPTION
retain viridis for 'one-sided' visualization, use a diverging one for 2-side vis.

A two-sided one now looks like:

![image](https://user-images.githubusercontent.com/4202567/104240288-1e7a7b80-545c-11eb-9a58-b94cda998e47.png)

BTW, the fact that these weights look so symmetric with opposite sign, I'm wondering if we should initialize them similarly, i.e. as we do now, copy and invert those random numbers on the matching patches. Maybe there are other ways we could exploit this (like compress nets or so).