### PR TITLE
Visualizer improvements

### DIFF
--- a/visualize.py
+++ b/visualize.py
@@ -14,6 +14,12 @@ class NNUEVisualizer():
         self.model = model
         self.args = args
 
+        import matplotlib as mpl
+        dpi = 100
+        mpl.rcParams["figure.figsize"] = (
+            self.args.default_width//dpi, self.args.default_height//dpi)
+        mpl.rcParams["figure.dpi"] = dpi
+
     def _process_fig(self, name):
         if self.args.save_dir:
             from os.path import join
@@ -111,7 +117,7 @@ class NNUEVisualizer():
             print(" done")
 
             # Input weights.
-            plt.figure(figsize=(16, 9))
+            plt.figure()
             plt.matshow(img.reshape((totaldim//totalx, totalx)),
                         fignum=0, vmin=vmin, vmax=vmax, cmap=cmap)
             plt.colorbar(fraction=0.046, pad=0.04)
@@ -134,7 +140,7 @@ class NNUEVisualizer():
 
             if not self.args.no_hist:
                 # Input weights histogram.
-                plt.figure(figsize=(16, 9))
+                plt.figure()
                 title_template = "input weights histogram [{NETNAME}]"
                 plt.hist(img, log=True, bins=(
                     np.arange(int(np.min(img)*127), int(np.max(img)*127+1))-0.5)/127)
@@ -176,7 +182,7 @@ class NNUEVisualizer():
                 plot_abs = True
                 cmap = 'viridis'
 
-            plt.figure(figsize=(16, 9))
+            plt.figure()
             gs = GridSpec(100, 100)
             plt.subplot(gs[:50, :])
             plt.matshow(np.abs(l1_weights) if plot_abs else l1_weights,
@@ -214,7 +220,7 @@ class NNUEVisualizer():
 
             if not self.args.no_hist:
                 # L1 weights histogram.
-                plt.figure(figsize=(16, 9))
+                plt.figure()
                 title_template = "L1 weights histogram [{NETNAME}]"
                 plt.hist(l1_weights.flatten(), log=True, bins=(
                     np.arange(int(np.min(l1_weights)*64), int(np.max(l1_weights)*64+1))-0.5)/64)
@@ -223,7 +229,7 @@ class NNUEVisualizer():
                 self._process_fig("l1-weights-histogram")
 
                 # L2 weights histogram.
-                plt.figure(figsize=(16, 9))
+                plt.figure()
                 title_template = "L2 weights histogram [{NETNAME}]"
                 plt.hist(l2_weights.flatten(), log=True, bins=(
                     np.arange(int(np.min(l2_weights)*64), int(np.max(l2_weights)*64+1))-0.5)/64)
@@ -238,7 +244,7 @@ class NNUEVisualizer():
             l2_biases = self.model.l2.bias.data.numpy()
             output_bias = self.model.output.bias.data.numpy()
 
-            plt.figure(figsize=(16, 9))
+            plt.figure()
             title_template = "biases [{NETNAME}]"
             plt.subplot(2, 1, 1)
             plt.plot(input_biases, '+', label='input')
@@ -277,6 +283,10 @@ def main():
         "--no-hist", action="store_true", help="Don't generate any histograms.")
     parser.add_argument(
         "--no-biases", action="store_true", help="Don't generate plots for biases.")
+    parser.add_argument(
+        "--default-width", default=1600, type=int, help="Default width of all plots (in pixels).")
+    parser.add_argument(
+        "--default-height", default=900, type=int, help="Default height of all plots (in pixels).")
     parser.add_argument(
         "--no-input-weights", action="store_true", help="Don't generate plots or histograms for input weights.")
     parser.add_argument(

--- a/visualize.py
+++ b/visualize.py
@@ -265,44 +265,60 @@ def main():
     parser.add_argument(
         "source", help="Source file (can be .ckpt, .pt or .nnue)")
     parser.add_argument(
-        "--input-weights-vmin", default=-1, type=float, help="Minimum of color map range for input weights (absolute values are plotted if this is positive or zero).")
+        "--input-weights-vmin", default=-1, type=float,
+        help="Minimum of color map range for input weights (absolute values are plotted if this is positive or zero).")
     parser.add_argument(
-        "--input-weights-vmax", default=1, type=float, help="Maximum of color map range for input weights.")
+        "--input-weights-vmax", default=1, type=float,
+        help="Maximum of color map range for input weights.")
     parser.add_argument(
-        "--input-weights-auto-scale", action="store_true", help="Use auto-scale for the color map range for input weights. This ignores input-weights-vmin and input-weights-vmax.")
+        "--input-weights-auto-scale", action="store_true",
+        help="Use auto-scale for the color map range for input weights. This ignores input-weights-vmin and input-weights-vmax.")
     parser.add_argument(
         "--order-input-neurons", action="store_true",
         help="Order the neurons of the input layer by the L1-norm (sum of absolute values) of their weights.")
     parser.add_argument(
-        "--fc-weights-vmin", default=-2, type=float, help="Minimum of color map range for fully-connected layer weights (absolute values are plotted if this is positive or zero).")
+        "--fc-weights-vmin", default=-2, type=float,
+        help="Minimum of color map range for fully-connected layer weights (absolute values are plotted if this is positive or zero).")
     parser.add_argument(
-        "--fc-weights-vmax", default=2, type=float, help="Maximum of color map range for fully-connected layer weights.")
+        "--fc-weights-vmax", default=2, type=float,
+        help="Maximum of color map range for fully-connected layer weights.")
     parser.add_argument(
-        "--fc-weights-auto-scale", action="store_true", help="Use auto-scale for the color map range for fully-connected layer weights. This ignores fc-weights-vmin and fc-weights-vmax.")
+        "--fc-weights-auto-scale", action="store_true",
+        help="Use auto-scale for the color map range for fully-connected layer weights. This ignores fc-weights-vmin and fc-weights-vmax.")
     parser.add_argument(
-        "--no-hist", action="store_true", help="Don't generate any histograms.")
+        "--no-hist", action="store_true",
+        help="Don't generate any histograms.")
     parser.add_argument(
-        "--no-biases", action="store_true", help="Don't generate plots for biases.")
+        "--no-biases", action="store_true",
+        help="Don't generate plots for biases.")
     parser.add_argument(
-        "--default-width", default=1600, type=int, help="Default width of all plots (in pixels).")
+        "--no-input-weights", action="store_true",
+        help="Don't generate plots or histograms for input weights.")
     parser.add_argument(
-        "--default-height", default=900, type=int, help="Default height of all plots (in pixels).")
+        "--no-fc-weights", action="store_true",
+        help="Don't generate plots or histograms for fully-connected layer weights.")
     parser.add_argument(
-        "--no-input-weights", action="store_true", help="Don't generate plots or histograms for input weights.")
+        "--default-width", default=1600, type=int,
+        help="Default width of all plots (in pixels).")
     parser.add_argument(
-        "--no-fc-weights", action="store_true", help="Don't generate plots or histograms for fully-connected layer weights.")
-    parser.add_argument("--save-dir", type=str, required=False,
-                        help="Save the plots in this directory.")
-    parser.add_argument("--save-prefix", type=str, required=False,
-                        help="Prefix used for the name of the saved files (default = network name).")
-    parser.add_argument("--dont-show", action="store_true",
-                        help="Don't show the plots.")
-    parser.add_argument("--net-name", type=str, required=False,
-                        help="Override the network name used in plot titles (default = network basename).")
+        "--default-height", default=900, type=int,
+        help="Default height of all plots (in pixels).")
+    parser.add_argument(
+        "--save-dir", type=str, required=False,
+        help="Save the plots in this directory.")
+    parser.add_argument(
+        "--save-prefix", type=str, required=False,
+        help="Prefix used for the name of the saved files (default = network name).")
+    parser.add_argument(
+        "--dont-show", action="store_true",
+        help="Don't show the plots.")
+    parser.add_argument(
+        "--net-name", type=str, required=False,
+        help="Override the network name used in plot titles (default = network basename).")
     features.add_argparse_args(parser)
     args = parser.parse_args()
 
-    assert args.features in ['HalfKP', 'HalfKP^']
+    assert args.features in ('HalfKP', 'HalfKP^')
     feature_set = features.get_feature_set_from_name(args.features)
 
     print("Visualizing {}".format(args.source))

--- a/visualize.py
+++ b/visualize.py
@@ -143,7 +143,7 @@ class NNUEVisualizer():
                 plt.figure()
                 title_template = "input weights histogram [{NETNAME}]"
                 plt.hist(img, log=True, bins=(
-                    np.arange(int(np.min(img)*127), int(np.max(img)*127+1))-0.5)/127)
+                    np.arange(int(np.min(img)*127)-1, int(np.max(img)*127)+3)-0.5)/127)
                 plt.title(title_template.format(NETNAME=self.args.net_name))
                 plt.tight_layout()
                 self._process_fig("input-weights-histogram")
@@ -223,7 +223,7 @@ class NNUEVisualizer():
                 plt.figure()
                 title_template = "L1 weights histogram [{NETNAME}]"
                 plt.hist(l1_weights.flatten(), log=True, bins=(
-                    np.arange(int(np.min(l1_weights)*64), int(np.max(l1_weights)*64+1))-0.5)/64)
+                    np.arange(int(np.min(l1_weights)*64)-1, int(np.max(l1_weights)*64)+3)-0.5)/64)
                 plt.title(title_template.format(NETNAME=self.args.net_name))
                 plt.tight_layout()
                 self._process_fig("l1-weights-histogram")
@@ -232,7 +232,7 @@ class NNUEVisualizer():
                 plt.figure()
                 title_template = "L2 weights histogram [{NETNAME}]"
                 plt.hist(l2_weights.flatten(), log=True, bins=(
-                    np.arange(int(np.min(l2_weights)*64), int(np.max(l2_weights)*64+1))-0.5)/64)
+                    np.arange(int(np.min(l2_weights)*64)-1, int(np.max(l2_weights)*64)+3)-0.5)/64)
                 plt.title(title_template.format(NETNAME=self.args.net_name))
                 plt.tight_layout()
                 self._process_fig("l2-weights-histogram")


### PR DESCRIPTION
Some visualizer improvements:
- Introduce `--input-weights-auto-scale` and `fc-weights-auto-scale` to be able to better investigate clipping in color maps.
- Add histogram for input weights.
- Log scale for all histograms + make sure we don't miss any outliers (e.g. handy for unquantized checkpoints).
- Add plot for all biases.
- Introduce options `--no-input-weights`, `--no-fc-weights`, `--no-biases`, `no-hist` to selectively omit generation of plots  (e.g. `--no-input-weights` now leads to very fast generation as no time-consuming input layer processing is needed anymore).
- Introduce options `--default-width` and `default-height` to set the default plot size in pixels (default: 1600x900). Can be very handy to generate ultra-high resolution (lossless) images.
- Refactoring (e.g. of common save figure logic).

Sample outputs for `python visualize.py ../research/run84run3/epoch=427.ckpt --features="HalfKP^" --input-weights-auto-scale --fc-weights-auto-scale --save-dir=. --dont-show`:

![epoch=427 ckpt_input-weights](https://user-images.githubusercontent.com/38748663/105627877-ad629d00-5e39-11eb-9dbc-c107f60fdd44.jpg)
![epoch=427 ckpt_input-weights-histogram](https://user-images.githubusercontent.com/38748663/105629210-f585bd80-5e41-11eb-8a71-c24c47de8832.jpg)
![epoch=427 ckpt_fc-weights](https://user-images.githubusercontent.com/38748663/105627881-b3f11480-5e39-11eb-91b6-4aa4777f06e9.jpg)
![epoch=427 ckpt_l1-weights-histogram](https://user-images.githubusercontent.com/38748663/105629175-cb340000-5e41-11eb-9c06-313883c6821e.jpg)
![epoch=427 ckpt_l2-weights-histogram](https://user-images.githubusercontent.com/38748663/105629177-ccfdc380-5e41-11eb-8a8c-23621b1c3cdf.jpg)
![epoch=427 ckpt_biases](https://user-images.githubusercontent.com/38748663/105627888-b94e5f00-5e39-11eb-88f9-6943971f25da.jpg)

Suggestions or remarks are welcome!