### PR TITLE
Use a reduced learning rate for the output layer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,20 @@ The default is:
 python train.py ... --features="HalfKP^"
 ```
 
+## Skipping certain fens in the training
+
+`--smart-fen-skipping` currently skips over moves where the king is in check, or where the bestMove is a capture (typical of non-quiet positions).
+`--random-fen-skipping N` skip N fens on average before using one. Uses fewer fens per game, useful with large data sets.
+
+## Current recommended training invocation
+
+```
+python train.py --smart-fen-skipping --random-fen-skipping 10 --batch-size 16384 --threads 8 --num-workers 8 --gpus 1 trainingdata validationdata 
+```
+best nets have been trained with 16B d9-scored nets, training runs >200 epochs
+
+
+
 # Export a network
 
 Using either a checkpoint (`.ckpt`) or serialized model (`.pt`),

--- a/model.py
+++ b/model.py
@@ -132,11 +132,11 @@ class NNUE(pl.LightningModule):
     self.step_(batch, batch_idx, 'test_loss')
 
   def configure_optimizers(self):
-    # Train the feature transformer layer with higher LR
+    # Train with a lower LR on the output layer
     LR = 1e-3
     train_params = [
-      {'params': self.get_layers(lambda x: self.input != x), 'lr': LR},
-      {'params': self.get_layers(lambda x: self.input == x), 'lr': LR * 10},
+      {'params': self.get_layers(lambda x: self.output != x), 'lr': LR},
+      {'params': self.get_layers(lambda x: self.output == x), 'lr': LR / 10},
     ]
     # increasing the eps leads to less saturated nets with a few dead neurons
     optimizer = ranger.Ranger(train_params, betas=(.9, 0.999), eps=1.0e-7)

--- a/model.py
+++ b/model.py
@@ -132,8 +132,26 @@ class NNUE(pl.LightningModule):
     self.step_(batch, batch_idx, 'test_loss')
 
   def configure_optimizers(self):
+    # Train the feature transformer layer with higher LR
+    LR = 1e-3
+    train_params = [
+      {'params': self.get_layers(lambda x: self.input != x), 'lr': LR},
+      {'params': self.get_layers(lambda x: self.input == x), 'lr': LR * 10},
+    ]
     # increasing the eps leads to less saturated nets with a few dead neurons
-    optimizer = ranger.Ranger(self.parameters(),betas=(.9, 0.999), eps=1.0e-7)
+    optimizer = ranger.Ranger(train_params, betas=(.9, 0.999), eps=1.0e-7)
     # Drop learning rate after 75 epochs
     scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=75, gamma=0.3)
     return [optimizer], [scheduler]
+
+  def get_layers(self, filt):
+    """
+    Returns a list of layers.
+    filt: Return true to include the given layer.
+    """
+    for i in self.children():
+      if filt(i):
+        if isinstance(i, nn.Linear):
+          for p in i.parameters():
+            if p.requires_grad:
+              yield p


### PR DESCRIPTION
lead to best net so far (run84/run3/epoch 245)
https://tests.stockfishchess.org/tests/view/600d41d7735dd7f0f0352c2d -15 Elo vs master
https://tests.stockfishchess.org/tests/view/600d42db735dd7f0f0352c2f  -3 Elo vs SV
    
trainer invoked as
```
python train.py --smart-fen-skipping --random-fen-skipping 10 --batch-size 16384 --threads 8 --num-workers 8 --gpus 1  large_gensfen_multipvdiff_100_d9.binpack large_gensfen_multipvdiff_100_d9.binpack
```
and run for > 200 epochs
