### PR TITLE
Visualize difference between two models.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,13 @@ python serialize.py nn.nnue converted.pt
 Visualize a network from either a checkpoint (`.ckpt`), a serialized model (`.pt`)
 or a SF NNUE file (`.nnue`).
 ```
-python visualize.py nn.nnue
+python visualize.py nn.nnue --features="HalfKP"
+```
+
+Visualize the difference between two networks from either a checkpoint (`.ckpt`), a serialized model (`.pt`)
+or a SF NNUE file (`.nnue`).
+```
+python visualize.py nn.nnue  --features="HalfKP" --ref-model nn.cpkt --ref-features="HalfKP^"
 ```
 
 # Logging


### PR DESCRIPTION
Add support to visualize the difference between two models (can be .cpkt, .pt or .nnue, both of mixed type is supported):
- New optional `--ref-model` argument.
- New optional `--ref-features` argument (default = source model features).
- Renamed `--net-name` to `--label`.

Example 1: visualize the difference between vondele `run84run3/epoch=427.ckpt` and `run84run3/epoch=245.ckpt`. Contrary to what I was thinking earlier, there are quite some differences between the two checkpoints.

```
python visualize.py ../research/run84run3/epoch=427.ckpt --features="HalfKP^" --ref-model ../research/run84run3/epoch=245.ckpt --input-weights-auto-scale --fc-weights-auto-scale --save-dir=.
```
![diff epoch=427 ckpt-epoch=245 ckpt_input-weights-histogram](https://user-images.githubusercontent.com/38748663/106355452-3a08d180-62f8-11eb-890b-1019461e3b7c.jpg)
![diff epoch=427 ckpt-epoch=245 ckpt_fc-weights](https://user-images.githubusercontent.com/38748663/106355453-3d03c200-62f8-11eb-9636-e9bb87a72f38.jpg)

Example 2: difference between master net nn-62ef826d1a6d.nnue and latest default net from SV run nn-03744f8d56d8.nnue.

```
python visualize.py ../research/nets/nn-62ef826d1a6d.nnue --features="HalfKP" --ref-model ../research/nets/nn-03744f8d56d8.nnue --input-weights-auto-scale --fc-weights-auto-scale --save-dir=.
```

![diff nn-62ef826d1a6d nnue-nn-03744f8d56d8 nnue_input-weights](https://user-images.githubusercontent.com/38748663/106355487-910ea680-62f8-11eb-8299-5557719fedb9.jpg)
![diff nn-62ef826d1a6d nnue-nn-03744f8d56d8 nnue_fc-weights](https://user-images.githubusercontent.com/38748663/106355491-92d86a00-62f8-11eb-8543-a4d2e2638aa8.jpg)
![diff nn-62ef826d1a6d nnue-nn-03744f8d56d8 nnue_input-weights-histogram](https://user-images.githubusercontent.com/38748663/106355493-94a22d80-62f8-11eb-8f5b-eb85a4133d77.jpg)
![diff nn-62ef826d1a6d nnue-nn-03744f8d56d8 nnue_l1-weights-histogram](https://user-images.githubusercontent.com/38748663/106355495-979d1e00-62f8-11eb-9163-c4e10dc1646d.jpg)
![diff nn-62ef826d1a6d nnue-nn-03744f8d56d8 nnue_l2-weights-histogram](https://user-images.githubusercontent.com/38748663/106355497-9966e180-62f8-11eb-9570-974f0fe7a0e2.jpg)
![diff nn-62ef826d1a6d nnue-nn-03744f8d56d8 nnue_biases](https://user-images.githubusercontent.com/38748663/106355502-9b30a500-62f8-11eb-8fd3-fa6f17d2b701.jpg)

This confirms that the master net is a post-optimization of the SV net of the L1 biases, L2 weights/biases and output weights/bias. @vondele Given its relatively low dimensionality (256), we might also consider tuning the input biases?