### PR TITLE
Fix virtual feature initialization

### DIFF
--- a/model.py
+++ b/model.py
@@ -41,7 +41,7 @@ class NNUE(pl.LightningModule):
   def _zero_virtual_feature_weights(self):
     weights = self.input.weight
     for a, b in self.feature_set.get_virtual_feature_ranges():
-      weights[a:b, :] = 0.0
+      weights[:, a:b] = 0.0
     self.input.weight = nn.Parameter(weights)
 
   '''


### PR DESCRIPTION
The weight shape of torch.nn.Linear is (out, in) ([source](https://pytorch.org/docs/stable/generated/torch.nn.Linear.html#torch.nn.Linear)).

In the case of HalfKP^, `print(a, b, weights.shape)` produces `41024 41728 torch.Size([256, 41728])`.