### PR TITLE
Add min_weight and max_weight parameters to Ranger.

### DIFF
--- a/ranger.py
+++ b/ranger.py
@@ -191,6 +191,12 @@ class Ranger(Optimizer):
                     G_grad = centralized_gradient(G_grad, use_gc=self.use_gc, gc_conv_only=self.gc_conv_only)
 
                 p_data_fp32.add_(G_grad, alpha=-step_size * group['lr'])
+
+                # constrain weights
+                min_weight = group['min_weight']
+                max_weight = group['max_weight']
+                p_data_fp32.clamp_(min_weight, max_weight)
+                
                 p.data.copy_(p_data_fp32)
 
                 # integrated look ahead...


### PR DESCRIPTION
This adds `ConstrainedRanger` which behaves just like ranger but additionally provides parameters `min_weight` and `max_weight` which define the valid range for weights. After each step the weights are clamped to this range. Would we want to merge this into `Ranger` instead? This is yet untested, I'll get to it soon.

This can be used for example like:
```
train_params = [
  {'params' : [self.input], 'lr' : LR, 'min_weight' : -(2**15-1)/127, 'max_weight' : (2**15-1)/127 },
  {'params' : [self.l1, self.l2], 'lr' : LR, 'min_weight' : -127/64, 'max_weight' : 127/64 },
  {'params' : [self.output], 'lr' : LR / 10, 'min_weight' : -127*127/9600, 'max_weight' : 127*127/9600 },
]
optimizer = ranger.ConstrainedRanger(train_params, betas=(.9, 0.999), eps=1.0e-7)
```