### PR TITLE
A new setup.

### DIFF
--- a/feature_set.py
+++ b/feature_set.py
@@ -102,3 +102,9 @@ class FeatureSet:
             real_offset += feature.num_real_features
             offset += feature.num_features
         return indices
+
+    def get_initial_psqt_features(self):
+        init = []
+        for feature in self.features:
+            init += feature.get_initial_psqt_features()
+        return init

--- a/features.py
+++ b/features.py
@@ -40,7 +40,7 @@ def get_available_feature_blocks_names():
     return list(iter(_feature_blocks_by_name))
 
 def add_argparse_args(parser):
-    _default_feature_set_name = 'HalfKP^'
+    _default_feature_set_name = 'HalfKA^'
     parser.add_argument("--features", dest='features', default=_default_feature_set_name, help="The feature set to use. Can be a union of feature blocks (for example P+HalfKP). \"^\" denotes a factorized block. Currently available feature blocks are: " + ', '.join(get_available_feature_blocks_names()))
 
 def _init():

--- a/halfka.py
+++ b/halfka.py
@@ -15,6 +15,28 @@ def halfka_idx(is_white_pov: bool, king_sq: int, sq: int, p: chess.Piece):
   p_idx = (p.piece_type - 1) * 2 + (p.color != is_white_pov)
   return 1 + orient(is_white_pov, sq) + p_idx * NUM_SQ + king_sq * NUM_PLANES
 
+def halfka_psqts():
+  # values copied from stockfish, in stockfish internal units
+  piece_values = {
+    chess.PAWN : 126,
+    chess.KNIGHT : 781,
+    chess.BISHOP : 825,
+    chess.ROOK : 1276,
+    chess.QUEEN : 2538
+  }
+
+  values = [0] * (NUM_PLANES * NUM_SQ)
+
+  for ksq in range(64):
+    for s in range(64):
+      for pt, val in piece_values.items():
+        idxw = halfka_idx(True, ksq, s, chess.Piece(pt, chess.WHITE))
+        idxb = halfka_idx(True, ksq, s, chess.Piece(pt, chess.BLACK))
+        values[idxw] = val
+        values[idxb] = -val
+
+  return values
+
 class Features(FeatureBlock):
   def __init__(self):
     super(Features, self).__init__('HalfKA', 0x5f134cb8, OrderedDict([('HalfKA', NUM_PLANES * NUM_SQ)]))
@@ -26,6 +48,9 @@ class Features(FeatureBlock):
         indices[halfka_idx(turn, orient(turn, board.king(turn)), sq, p)] = 1.0
       return indices
     return (piece_features(chess.WHITE), piece_features(chess.BLACK))
+
+  def get_initial_psqt_features(self):
+    return halfka_psqts()
 
 class FactorizedFeatures(FeatureBlock):
   def __init__(self):
@@ -41,6 +66,9 @@ class FactorizedFeatures(FeatureBlock):
     a_idx = idx % NUM_PLANES - 1
 
     return [idx, self.get_factor_base_feature('A') + a_idx]
+
+  def get_initial_psqt_features(self):
+    return halfka_psqts() + [0] * (NUM_SQ * NUM_PT)
 
 '''
 This is used by the features module for discovery of feature blocks.

--- a/model.py
+++ b/model.py
@@ -21,7 +21,8 @@ class NNUE(pl.LightningModule):
   """
   def __init__(self, feature_set, lambda_=1.0):
     super(NNUE, self).__init__()
-    self.input = nn.Linear(feature_set.num_features, L1)
+    # One more value for PSQT
+    self.input = nn.Linear(feature_set.num_features, L1 + 1)
     self.feature_set = feature_set
     self.l1 = nn.Linear(2 * L1, L2)
     self.l2 = nn.Linear(L2, L3)
@@ -30,6 +31,7 @@ class NNUE(pl.LightningModule):
 
     self._zero_virtual_feature_weights()
     self._correct_init_biases()
+    self._init_psqt()
 
   '''
   We zero all virtual feature weights because during serialization to .nnue
@@ -58,6 +60,7 @@ class NNUE(pl.LightningModule):
     output_bias = self.output.bias
     with torch.no_grad():
       input_bias.add_(0.5)
+      input_bias[L1] = 0.0
       l1_bias.add_(0.5)
       l2_bias.add_(0.5)
       output_bias.fill_(0.0)
@@ -65,6 +68,16 @@ class NNUE(pl.LightningModule):
     self.l1.bias = nn.Parameter(l1_bias)
     self.l2.bias = nn.Parameter(l2_bias)
     self.output.bias = nn.Parameter(output_bias)
+
+  def _init_psqt(self):
+    input_weights = self.input.weight
+    # 1.0 / kPonanzaConstant
+    scale = 1 / 600
+    with torch.no_grad():
+      initial_values = self.feature_set.get_initial_psqt_features()
+      assert len(initial_values) == self.feature_set.num_features
+      input_weights[L1, :] = torch.FloatTensor(initial_values) * scale
+    self.input.weight = nn.Parameter(input_weights)
 
   '''
   This method attempts to convert the model from using the self.feature_set
@@ -106,14 +119,21 @@ class NNUE(pl.LightningModule):
       raise Exception('Cannot change feature set from {} to {}.'.format(self.feature_set.name, new_feature_set.name))
 
   def forward(self, us, them, w_in, b_in):
-    w = self.input(w_in)
-    b = self.input(b_in)
+    wp = self.input(w_in)
+    bp = self.input(b_in)
+    # Split the result into input for the next layer and PSQT.
+    # PSQT will be forwarded directly to the output
+    w, wpsqt = torch.split(wp, L1, dim=1)
+    b, bpsqt = torch.split(bp, L1, dim=1)
     l0_ = (us * torch.cat([w, b], dim=1)) + (them * torch.cat([b, w], dim=1))
     # clamp here is used as a clipped relu to (0.0, 1.0)
     l0_ = torch.clamp(l0_, 0.0, 1.0)
     l1_ = torch.clamp(self.l1(l0_), 0.0, 1.0)
     l2_ = torch.clamp(self.l2(l1_), 0.0, 1.0)
-    x = self.output(l2_)
+    # Since NNUE requires evaluating two perspectives we need to take the average
+    # of the PSQT values and adjust the sign to be for side to move
+    # (us - 0.5) is 0.5 for white, -0.5 for black; which is average * sign
+    x = self.output(l2_) + (wpsqt - bpsqt) * (us - 0.5)
     return x
 
   def step_(self, batch, batch_idx, loss_type):

--- a/model.py
+++ b/model.py
@@ -142,11 +142,12 @@ class NNUE(pl.LightningModule):
     # 600 is the kPonanzaConstant scaling factor needed to convert the training net output to a score.
     # This needs to match the value used in the serializer
     nnue2score = 600
-    scaling = 361
+    in_scaling = 410
+    out_scaling = 361
 
-    q = self(us, them, white, black) * nnue2score / scaling
+    q = self(us, them, white, black) * nnue2score / out_scaling
     t = outcome
-    p = (score / scaling).sigmoid()
+    p = (score / in_scaling).sigmoid()
 
     epsilon = 1e-12
     teacher_entropy = -(p * (p + epsilon).log() + (1.0 - p) * (1.0 - p + epsilon).log())

--- a/serialize.py
+++ b/serialize.py
@@ -24,7 +24,7 @@ def ascii_hist(name, x, bins=6):
     print('{0}| {1}'.format(xi,bar))
 
 # hardcoded for now
-VERSION = 0x7AF32F16
+VERSION = 0x7AF32F20
 
 class NNUEWriter():
   """
@@ -64,7 +64,7 @@ class NNUEWriter():
   def write_header(self, model, fc_hash):
     self.int32(VERSION) # version
     self.int32(fc_hash ^ model.feature_set.hash ^ (M.L1*2)) # halfkp network hash
-    description = b"Features=HalfKP(Friend)[41024->256x2],"
+    description = b"Features=HalfKA(Friend)[49216->256x2],"
     description += b"Network=AffineTransform[1<-32](ClippedReLU[32](AffineTransform[32<-32]"
     description += b"(ClippedReLU[32](AffineTransform[32<-512](InputSlice[512(0:512)])))))"
     self.int32(len(description)) # Network definition
@@ -83,16 +83,20 @@ class NNUEWriter():
     # int16 bias = round(x * 127)
     # int16 weight = round(x * 127)
     layer = model.input
-    bias = layer.bias.data
+    bias = layer.bias.data[:M.L1]
     bias = bias.mul(127).round().to(torch.int16)
     ascii_hist('ft bias:', bias.numpy())
     self.buf.extend(bias.flatten().numpy().tobytes())
 
     weight = self.coalesce_ft_weights(model, layer)
-    weight = weight.mul(127).round().to(torch.int16)
+    weight0 = weight[:M.L1, :]
+    psqtweight0 = weight[M.L1, :]
+    weight = weight0.mul(127).round().to(torch.int16)
+    psqtweight = psqtweight0.mul(9600).round().to(torch.int32) # kPonanzaConstant * FV_SCALE = 9600
     ascii_hist('ft weight:', weight.numpy())
     # weights stored as [41024][256], so we need to transpose the pytorch [256][41024]
     self.buf.extend(weight.transpose(0, 1).flatten().numpy().tobytes())
+    self.buf.extend(psqtweight.flatten().numpy().tobytes())
 
   def write_fc_layer(self, layer, is_output=False):
     # FC layers are stored as int8 weights, and int32 biases
@@ -159,10 +163,15 @@ class NNUEReader():
     return d
 
   def read_feature_transformer(self, layer):
-    layer.bias.data = self.tensor(numpy.int16, layer.bias.shape).divide(127.0)
+    bias = self.tensor(numpy.int16, [layer.bias.shape[0]-1]).divide(127.0)
+    layer.bias.data = torch.cat([bias, torch.tensor([0])])
     # weights stored as [41024][256], so we need to transpose the pytorch [256][41024]
-    weights = self.tensor(numpy.int16, layer.weight.shape[::-1])
-    layer.weight.data = weights.divide(127.0).transpose(0, 1)
+    shape = layer.weight.shape[::-1]
+    weights = self.tensor(numpy.int16, [shape[0], shape[1]-1])
+    psqtweights = self.tensor(numpy.int32, [1, shape[0]])
+    weights = weights.divide(127.0).transpose(0, 1)
+    psqtweights = psqtweights.divide(9600.0)
+    layer.weight.data = torch.cat([weights, psqtweights], dim=0)
 
   def read_fc_layer(self, layer, is_output=False):
     # FC layers are stored as int8 weights, and int32 biases


### PR DESCRIPTION
I've come up to a setup that to my knowledge produced the best 256x2-32-32-1 net and the best 512x2-16-32-1 net yet.

256x2-32-32-1: https://tests.stockfishchess.org/tests/view/60659d0b2b2df919fd5f028d (using hybrid, tested directly against master; so the usual setup for STC tests). Same test with the newly possible NNUE-PSQT hybrid https://tests.stockfishchess.org/tests/view/60659dab2b2df919fd5f028f
512x2-16-32-1: https://tests.stockfishchess.org/tests/view/6065a5bd2b2df919fd5f02a0 (using a psqt hybrid, tested directly against master; usual STC setup but hybrid approach is different)

The changes are the following:
1. Initialization of biases is changed. Hidden neuron biases are initialized to half of the activation range. Output bias to 0.
2. Change architecture from HalfKP to HalfKA (important to have features for kings, and flip instead of rotate) (still uses the 641 features per plane and wastes one plane (so it could be made ~8% smaller). This can be improved in the future, but would need a new name, for example HalfKAv2. This is for another PR.
3. Weights are clipped after each step to the range of quantization. (I changed the ranger.py file. Does it need any changes to the header due to these changes?)
4. An additional value is added for each feature, with the idea for it to represent the PSQT value. Value of this feature is directly forwarded to the output. With how the NNUE works it is necessary for this value to be evaluated for both perspectives and the average be chosen.
5. Change scaling of the eval->perf% sigmoid for the input data from 361 to 410 (which matches closer the empirical value for depth 9 data, which is the most popular right now. This still should be adjusted for other data, but the effect seems to be small.)

The stockfish branch which can use these nets can be found here: https://github.com/Sopel97/Stockfish/tree/new_setup

More data and history for these changes can be found in https://docs.google.com/document/d/1gTlrr02qSNKiXNZ_SuO4-RjK4MXBiFlLE6jvNqqMkAY/edit?usp=sharing.