### PR TITLE
Make cross_eval_check script form batches from fens, delegated to the data loader.

### DIFF
--- a/nnue_dataset.py
+++ b/nnue_dataset.py
@@ -106,6 +106,25 @@ fetch_next_sparse_batch.restype = SparseBatchPtr
 fetch_next_sparse_batch.argtypes = [ctypes.c_void_p]
 destroy_sparse_batch = dll.destroy_sparse_batch
 
+get_sparse_batch_from_fens = dll.get_sparse_batch_from_fens
+get_sparse_batch_from_fens.restype = SparseBatchPtr
+get_sparse_batch_from_fens.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.POINTER(ctypes.c_char_p), ctypes.POINTER(ctypes.c_int), ctypes.POINTER(ctypes.c_int), ctypes.POINTER(ctypes.c_int)]
+
+def make_sparse_batch_from_fens(feature_set, fens, scores, plies, results):
+    results_ = (ctypes.c_int*len(scores))()
+    scores_ = (ctypes.c_int*len(plies))()
+    plies_ = (ctypes.c_int*len(results))()
+    fens_ = (ctypes.c_char_p * len(fens))()
+    fens_[:] = [fen.encode('utf-8') for fen in fens]
+    for i, v in enumerate(scores):
+        scores_[i] = v
+    for i, v in enumerate(plies):
+        plies_[i] = v
+    for i, v in enumerate(results):
+        results_[i] = v
+    b = get_sparse_batch_from_fens(feature_set.name.encode('utf-8'), len(fens), fens_, scores_, plies_, results_)
+    return b
+
 class SparseBatchProvider(TrainingDataProvider):
     def __init__(self, feature_set, filename, batch_size, cyclic=True, num_workers=1, filtered=False, random_fen_skipping=0, device='cpu'):
         super(SparseBatchProvider, self).__init__(


### PR DESCRIPTION
Thich means that there's no need to implement the feature transformer index generation in python code. This is particularily important for new feature blocks. Before this the features had to be generated in 3 places - data loader, player, trainer. Now the trainer never needs to know the feature indices.

I also might become useful for other things. The newly added function is `nnue_dataset.make_sparse_batch_from_fens`, which takes a feature set, list of fens, list of scores, list of ply numbers, and a list of results (in -1, 0, 1 form). Currently for each position some legal move is generated, as it doesn't really matter, but in the future the move could also be passed as an argument. 