### PR TITLE
Update trainer to the new architecture.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ python train.py --resume_from_checkpoint <path> ...
 python train.py --gpus 1 ...
 ```
 ## Feature set selection
-By default the trainer uses a factorized HalfKP feature set (named "HalfKP^")
+By default the trainer uses a factorized HalfKAv2 feature set (named "HalfKAv2^")
 If you wish to change the feature set used then you can use the `--features=NAME` option. For the list of available features see `--help`
 The default is:
 ```
-python train.py ... --features="HalfKP^"
+python train.py ... --features="HalfKAv2^"
 ```
 
 ## Skipping certain fens in the training
@@ -69,7 +69,7 @@ python train.py ... --features="HalfKP^"
 ## Current recommended training invocation
 
 ```
-python train.py --smart-fen-skipping --random-fen-skipping 10 --batch-size 16384 --threads 8 --num-workers 8 --gpus 1 trainingdata validationdata
+python train.py --smart-fen-skipping --random-fen-skipping 3 --batch-size 16384 --threads 8 --num-workers 8 --gpus 1 trainingdata validationdata
 ```
 best nets have been trained with 16B d9-scored nets, training runs >200 epochs
 
@@ -96,13 +96,13 @@ python serialize.py nn.nnue converted.pt
 Visualize a network from either a checkpoint (`.ckpt`), a serialized model (`.pt`)
 or a SF NNUE file (`.nnue`).
 ```
-python visualize.py nn.nnue --features="HalfKP"
+python visualize.py nn.nnue --features="HalfKAv2"
 ```
 
 Visualize the difference between two networks from either a checkpoint (`.ckpt`), a serialized model (`.pt`)
 or a SF NNUE file (`.nnue`).
 ```
-python visualize.py nn.nnue  --features="HalfKP" --ref-model nn.cpkt --ref-features="HalfKP^"
+python visualize.py nn.nnue  --features="HalfKAv2" --ref-model nn.cpkt --ref-features="HalfKAv2^"
 ```
 
 # Logging

--- a/cross_check_eval.py
+++ b/cross_check_eval.py
@@ -16,9 +16,9 @@ def make_data_reader(data_path, feature_set):
     return nnue_bin_dataset.NNUEBinData(data_path, feature_set)
 
 def eval_model_batch(model, batch):
-   us, them, white_indices, white_values, black_indices, black_values, outcome, score = batch.contents.get_tensors('cpu')
+    us, them, white_indices, white_values, black_indices, black_values, outcome, score, psqt_indices, layer_stack_indices = batch.contents.get_tensors('cuda')
 
-    evals = [v.item() for v in model.forward(us, them, white_indices, white_values, black_indices, black_values) * 600.0]
+    evals = [v.item() for v in model.forward(us, them, white_indices, white_values, black_indices, black_values, psqt_indices, layer_stack_indices) * 600.0]
     for i in range(len(evals)):
         if them[i] > 0.5:
             evals[i] = -evals[i]
@@ -80,6 +80,7 @@ def main():
     else:
       model = read_model(args.net, feature_set)
     model.eval()
+    model.cuda()
     data_reader = make_data_reader(args.data, feature_set)
 
     fens = []

--- a/feature_set.py
+++ b/feature_set.py
@@ -102,3 +102,9 @@ class FeatureSet:
             real_offset += feature.num_real_features
             offset += feature.num_features
         return indices
+
+    def get_initial_psqt_features(self):
+        init = []
+        for feature in self.features:
+            init += feature.get_initial_psqt_features()
+        return init

--- a/feature_set.py
+++ b/feature_set.py
@@ -1,6 +1,10 @@
 from collections import OrderedDict
 from feature_block import *
 import torch
+import chess
+
+PSQT_BUCKETS = 8
+LS_BUCKETS = 8
 
 def _calculate_features_hash(features):
     if len(features) == 1:
@@ -29,6 +33,27 @@ class FeatureSet:
         self.num_real_features = sum(feature.num_real_features for feature in features)
         self.num_virtual_features = sum(feature.num_virtual_features for feature in features)
         self.num_features = sum(feature.num_features for feature in features)
+        self.num_psqt_buckets = PSQT_BUCKETS
+        self.num_ls_buckets = LS_BUCKETS
+
+    def get_ls_index(self, board: chess.Board):
+        return self.get_psqt_index(board)
+
+    def get_psqt_index(self, board: chess.Board):
+        all_pieces = \
+            board.pieces(chess.PAWN, chess.WHITE) | \
+            board.pieces(chess.KNIGHT, chess.WHITE) | \
+            board.pieces(chess.BISHOP, chess.WHITE) | \
+            board.pieces(chess.ROOK, chess.WHITE) | \
+            board.pieces(chess.QUEEN, chess.WHITE) | \
+            board.pieces(chess.KING, chess.WHITE) | \
+            board.pieces(chess.PAWN, chess.BLACK) | \
+            board.pieces(chess.KNIGHT, chess.BLACK) | \
+            board.pieces(chess.BISHOP, chess.BLACK) | \
+            board.pieces(chess.ROOK, chess.BLACK) | \
+            board.pieces(chess.QUEEN, chess.BLACK) | \
+            board.pieces(chess.KING, chess.BLACK)
+        return (len(all_pieces) - 1) // 4
 
     '''
     This method returns the feature ranges for the virtual factors of the
@@ -42,6 +67,15 @@ class FeatureSet:
         for feature in self.features:
             if feature.num_virtual_features:
                 ranges.append((offset + feature.num_real_features, offset + feature.num_features))
+            offset += feature.num_features
+
+        return ranges
+
+    def get_real_feature_ranges(self):
+        ranges = []
+        offset = 0
+        for feature in self.features:
+            ranges.append((offset, offset + feature.num_real_features))
             offset += feature.num_features
 
         return ranges

--- a/features.py
+++ b/features.py
@@ -11,8 +11,9 @@ of feature block classes in that module.
 '''
 import halfkp
 import halfka
+import halfka_v2
 
-_feature_modules = [halfkp, halfka]
+_feature_modules = [halfkp, halfka, halfka_v2]
 
 _feature_blocks_by_name = dict()
 

--- a/features.py
+++ b/features.py
@@ -41,7 +41,7 @@ def get_available_feature_blocks_names():
     return list(iter(_feature_blocks_by_name))
 
 def add_argparse_args(parser):
-    _default_feature_set_name = 'HalfKP^'
+    _default_feature_set_name = 'HalfKAv2^'
     parser.add_argument("--features", dest='features', default=_default_feature_set_name, help="The feature set to use. Can be a union of feature blocks (for example P+HalfKP). \"^\" denotes a factorized block. Currently available feature blocks are: " + ', '.join(get_available_feature_blocks_names()))
 
 def _init():

--- a/halfka.py
+++ b/halfka.py
@@ -15,6 +15,28 @@ def halfka_idx(is_white_pov: bool, king_sq: int, sq: int, p: chess.Piece):
   p_idx = (p.piece_type - 1) * 2 + (p.color != is_white_pov)
   return 1 + orient(is_white_pov, sq) + p_idx * NUM_SQ + king_sq * NUM_PLANES
 
+def halfka_psqts():
+  # values copied from stockfish, in stockfish internal units
+  piece_values = {
+    chess.PAWN : 126,
+    chess.KNIGHT : 781,
+    chess.BISHOP : 825,
+    chess.ROOK : 1276,
+    chess.QUEEN : 2538
+  }
+
+  values = [0] * (NUM_PLANES * NUM_SQ)
+
+  for ksq in range(64):
+    for s in range(64):
+      for pt, val in piece_values.items():
+        idxw = halfka_idx(True, ksq, s, chess.Piece(pt, chess.WHITE))
+        idxb = halfka_idx(True, ksq, s, chess.Piece(pt, chess.BLACK))
+        values[idxw] = val
+        values[idxb] = -val
+
+  return values
+
 class Features(FeatureBlock):
   def __init__(self):
     super(Features, self).__init__('HalfKA', 0x5f134cb8, OrderedDict([('HalfKA', NUM_PLANES * NUM_SQ)]))
@@ -26,6 +48,9 @@ class Features(FeatureBlock):
         indices[halfka_idx(turn, orient(turn, board.king(turn)), sq, p)] = 1.0
       return indices
     return (piece_features(chess.WHITE), piece_features(chess.BLACK))
+
+  def get_initial_psqt_features(self):
+    return halfka_psqts()
 
 class FactorizedFeatures(FeatureBlock):
   def __init__(self):
@@ -41,6 +66,9 @@ class FactorizedFeatures(FeatureBlock):
     a_idx = idx % NUM_PLANES - 1
 
     return [idx, self.get_factor_base_feature('A') + a_idx]
+
+  def get_initial_psqt_features(self):
+    return halfka_psqts() + [0] * (NUM_SQ * NUM_PT)
 
 '''
 This is used by the features module for discovery of feature blocks.

--- a/halfka_v2.py
+++ b/halfka_v2.py
@@ -1,0 +1,86 @@
+import chess
+import torch
+import feature_block
+from collections import OrderedDict
+from feature_block import *
+
+NUM_SQ = 64
+NUM_PT_REAL = 11
+NUM_PT_VIRTUAL = 12
+NUM_PLANES_REAL = NUM_SQ * NUM_PT_REAL
+NUM_PLANES_VIRTUAL = NUM_SQ * NUM_PT_VIRTUAL
+NUM_INPUTS = NUM_PLANES_REAL * NUM_SQ
+
+def orient(is_white_pov: bool, sq: int):
+  return (56 * (not is_white_pov)) ^ sq
+
+def halfka_idx(is_white_pov: bool, king_sq: int, sq: int, p: chess.Piece):
+  p_idx = (p.piece_type - 1) * 2 + (p.color != is_white_pov)
+  if p_idx == 11:
+    p_idx -= 1
+  return orient(is_white_pov, sq) + p_idx * NUM_SQ + king_sq * NUM_PLANES_REAL
+
+def halfka_psqts():
+  # values copied from stockfish, in stockfish internal units
+  piece_values = {
+    chess.PAWN : 126,
+    chess.KNIGHT : 781,
+    chess.BISHOP : 825,
+    chess.ROOK : 1276,
+    chess.QUEEN : 2538
+  }
+
+  values = [0] * (NUM_PLANES_REAL * NUM_SQ)
+
+  for ksq in range(64):
+    for s in range(64):
+      for pt, val in piece_values.items():
+        idxw = halfka_idx(True, ksq, s, chess.Piece(pt, chess.WHITE))
+        idxb = halfka_idx(True, ksq, s, chess.Piece(pt, chess.BLACK))
+        values[idxw] = val
+        values[idxb] = -val
+
+  return values
+
+class Features(FeatureBlock):
+  def __init__(self):
+    super(Features, self).__init__('HalfKAv2', 0x5f234cb8, OrderedDict([('HalfKAv2', NUM_PLANES_REAL * NUM_SQ)]))
+
+  def get_active_features(self, board: chess.Board):
+    def piece_features(turn):
+      indices = torch.zeros(NUM_PLANES_REAL * NUM_SQ)
+      for sq, p in board.piece_map().items():
+        indices[halfka_idx(turn, orient(turn, board.king(turn)), sq, p)] = 1.0
+      return indices
+    return (piece_features(chess.WHITE), piece_features(chess.BLACK))
+
+  def get_initial_psqt_features(self):
+    return halfka_psqts()
+
+class FactorizedFeatures(FeatureBlock):
+  def __init__(self):
+    super(FactorizedFeatures, self).__init__('HalfKAv2^', 0x5f234cb8, OrderedDict([('HalfKAv2', NUM_PLANES_REAL * NUM_SQ), ('A', NUM_PLANES_VIRTUAL)]))
+
+  def get_active_features(self, board: chess.Board):
+    raise Exception('Not supported yet, you must use the c++ data loader for factorizer support during training')
+
+  def get_feature_factors(self, idx):
+    if idx >= self.num_real_features:
+      raise Exception('Feature must be real')
+
+    a_idx = idx % NUM_PLANES_REAL
+    k_idx = idx // NUM_PLANES_REAL
+
+    if a_idx // NUM_SQ == 10 and k_idx != a_idx % NUM_SQ:
+      a_idx += NUM_SQ
+
+    return [idx, self.get_factor_base_feature('A') + a_idx]
+
+  def get_initial_psqt_features(self):
+    return halfka_psqts() + [0] * NUM_PLANES_VIRTUAL
+
+'''
+This is used by the features module for discovery of feature blocks.
+'''
+def get_feature_block_clss():
+  return [Features, FactorizedFeatures]

--- a/halfkp.py
+++ b/halfkp.py
@@ -29,6 +29,9 @@ class Features(FeatureBlock):
       return indices
     return (piece_features(chess.WHITE), piece_features(chess.BLACK))
 
+  def get_initial_psqt_features(self):
+    raise Exception('Not supported yet. See HalfKA')
+
 class FactorizedFeatures(FeatureBlock):
   def __init__(self):
     super(FactorizedFeatures, self).__init__('HalfKP^', 0x5d69d5b8, OrderedDict([('HalfKP', NUM_PLANES * NUM_SQ), ('HalfK', NUM_SQ), ('P', NUM_SQ * 10 )]))
@@ -59,6 +62,9 @@ class FactorizedFeatures(FeatureBlock):
     p_idx = idx % NUM_PLANES - 1
 
     return [idx, self.get_factor_base_feature('HalfK') + k_idx, self.get_factor_base_feature('P') + p_idx]
+
+  def get_initial_psqt_features(self):
+    raise Exception('Not supported yet. See HalfKA^')
 
 '''
 This is used by the features module for discovery of feature blocks.

--- a/model.py
+++ b/model.py
@@ -8,8 +8,8 @@ import copy
 from feature_transformer import DoubleFeatureTransformerSlice
 
 # 3 layer fully connected network
-L1 = 256
-L2 = 32
+L1 = 512
+L2 = 16
 L3 = 32
 
 def coalesce_ft_weights(model, layer):

--- a/model.py
+++ b/model.py
@@ -306,7 +306,7 @@ class NNUE(pl.LightningModule):
       {'params' : [self.layer_stacks.output.bias], 'lr' : LR / 10 },
     ]
     # increasing the eps leads to less saturated nets with a few dead neurons
-    optimizer = ranger.Ranger(train_params, betas=(.9, 0.999), eps=1.0e-7)
+    optimizer = ranger.Ranger(train_params, betas=(.9, 0.999), eps=1.0e-7, gc_loc=False, use_gc=False)
     # Drop learning rate after 75 epochs
     scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=75, gamma=0.3)
     return [optimizer], [scheduler]

--- a/model.py
+++ b/model.py
@@ -268,19 +268,14 @@ class NNUE(pl.LightningModule):
     in_scaling = 410
     out_scaling = 361
 
-    q = self(us, them, white_indices, white_values, black_indices, black_values, psqt_indices, layer_stack_indices) * nnue2score / scaling
+    q = (self(us, them, white_indices, white_values, black_indices, black_values, psqt_indices, layer_stack_indices) * nnue2score / out_scaling).sigmoid()
     t = outcome
     p = (score / in_scaling).sigmoid()
 
-    epsilon = 1e-12
-    teacher_entropy = -(p * (p + epsilon).log() + (1.0 - p) * (1.0 - p + epsilon).log())
-    outcome_entropy = -(t * (t + epsilon).log() + (1.0 - t) * (1.0 - t + epsilon).log())
-    teacher_loss = -(p * F.logsigmoid(q) + (1.0 - p) * F.logsigmoid(-q))
-    outcome_loss = -(t * F.logsigmoid(q) + (1.0 - t) * F.logsigmoid(-q))
-    result  = self.lambda_ * teacher_loss    + (1.0 - self.lambda_) * outcome_loss
-    entropy = self.lambda_ * teacher_entropy + (1.0 - self.lambda_) * outcome_entropy
-    loss = result.mean() - entropy.mean()
+    loss = (p - q).square().mean()
+
     self.log(loss_type, loss)
+
     return loss
 
     # MSE Loss function for debugging

--- a/model.py
+++ b/model.py
@@ -294,7 +294,7 @@ class NNUE(pl.LightningModule):
 
   def configure_optimizers(self):
     # Train with a lower LR on the output layer
-    LR = 1e-3
+    LR = 1.5e-3
     train_params = [
       {'params' : get_parameters([self.input]), 'lr' : LR, 'gc_dim' : 0 },
       {'params' : [self.layer_stacks.l1_fact.weight], 'lr' : LR },
@@ -308,5 +308,5 @@ class NNUE(pl.LightningModule):
     # increasing the eps leads to less saturated nets with a few dead neurons
     optimizer = ranger.Ranger(train_params, betas=(.9, 0.999), eps=1.0e-7, gc_loc=False, use_gc=False)
     # Drop learning rate after 75 epochs
-    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=75, gamma=0.3)
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1, gamma=0.987)
     return [optimizer], [scheduler]

--- a/nnue_bin_dataset.py
+++ b/nnue_bin_dataset.py
@@ -54,7 +54,9 @@ class ToTensor(object):
     outcome = torch.tensor([outcome])
     score = torch.tensor([score])
     white, black = self.features.get_active_features(bd)
-    return us.float(), them.float(), white.float(), black.float(), outcome.float(), score.float()
+    lsindex = torch.tensor([self.features.get_ls_index(bd)])
+    psqtindex = torch.tensor([self.features.get_psqt_index(bd)])
+    return us.float(), them.float(), white.float(), black.float(), outcome.float(), score.float(), psqtindex.long(), lsindex.long()
 
 class RandomFlip(object):
   def __call__(self, sample):

--- a/nnue_dataset.py
+++ b/nnue_dataset.py
@@ -26,7 +26,9 @@ class SparseBatch(ctypes.Structure):
         ('white', ctypes.POINTER(ctypes.c_int)),
         ('black', ctypes.POINTER(ctypes.c_int)),
         ('white_values', ctypes.POINTER(ctypes.c_float)),
-        ('black_values', ctypes.POINTER(ctypes.c_float))
+        ('black_values', ctypes.POINTER(ctypes.c_float)),
+        ('psqt_indices', ctypes.POINTER(ctypes.c_int)),
+        ('layer_stack_indices', ctypes.POINTER(ctypes.c_int)),
     ]
 
     def get_tensors(self, device):
@@ -38,7 +40,9 @@ class SparseBatch(ctypes.Structure):
         them = 1.0 - us
         outcome = torch.from_numpy(np.ctypeslib.as_array(self.outcome, shape=(self.size, 1))).pin_memory().to(device=device, non_blocking=True)
         score = torch.from_numpy(np.ctypeslib.as_array(self.score, shape=(self.size, 1))).pin_memory().to(device=device, non_blocking=True)
-        return us, them, white_indices, white_values, black_indices, black_values, outcome, score
+        psqt_indices = torch.from_numpy(np.ctypeslib.as_array(self.psqt_indices, shape=(self.size,))).long().pin_memory().to(device=device, non_blocking=True)
+        layer_stack_indices = torch.from_numpy(np.ctypeslib.as_array(self.layer_stack_indices, shape=(self.size,))).long().pin_memory().to(device=device, non_blocking=True)
+        return us, them, white_indices, white_values, black_indices, black_values, outcome, score, psqt_indices, layer_stack_indices
 
 SparseBatchPtr = ctypes.POINTER(SparseBatch)
 

--- a/perf_sigmoid_fitter.py
+++ b/perf_sigmoid_fitter.py
@@ -63,7 +63,7 @@ def gather_statistics_from_batches(batches, bucket_size):
     data = dict()
     i = 0
     for batch in batches:
-        us, them, white, black, outcome, score = batch
+        us, them, white_indices, white_values, black_indices, black_values, outcome, score, psqt_indices, layer_stack_indices = batch
         batch_size = len(us)
         bucket = torch.round(score / bucket_size) * bucket_size
         perf = outcome

--- a/ranger.py
+++ b/ranger.py
@@ -43,8 +43,7 @@ class Ranger(Optimizer):
                  alpha=0.5, k=6, N_sma_threshhold=5,           # Ranger options
                  betas=(.95, 0.999), eps=1e-5, weight_decay=0,  # Adam options
                  # Gradient centralization on or off, applied to conv layers only or conv + fc layers
-                 use_gc=True, gc_conv_only=False, gc_loc=True,
-                 min_weight=-1000000.0, max_weight=1000000
+                 use_gc=True, gc_conv_only=False, gc_loc=True
                  ):
 
         # parameter checks
@@ -65,7 +64,7 @@ class Ranger(Optimizer):
         # prep defaults and init torch.optim base
         defaults = dict(lr=lr, alpha=alpha, k=k, step_counter=0, betas=betas,
                         N_sma_threshhold=N_sma_threshhold, eps=eps, weight_decay=weight_decay,
-                        min_weight=min_weight, max_weight=max_weight, gc_dim=None)
+                        gc_dim=None)
         super().__init__(params, defaults)
 
         # adjustable threshold
@@ -190,11 +189,6 @@ class Ranger(Optimizer):
                     G_grad = centralized_gradient(G_grad, use_gc=self.use_gc, gc_conv_only=self.gc_conv_only, dim=group['gc_dim'])
 
                 p_data_fp32.add_(G_grad, alpha=-step_size * group['lr'])
-
-                # constrain weights
-                min_weight = group['min_weight']
-                max_weight = group['max_weight']
-                p_data_fp32.clamp_(min_weight, max_weight)
 
                 p.data.copy_(p_data_fp32)
 

--- a/ranger.py
+++ b/ranger.py
@@ -43,7 +43,8 @@ class Ranger(Optimizer):
                  alpha=0.5, k=6, N_sma_threshhold=5,           # Ranger options
                  betas=(.95, 0.999), eps=1e-5, weight_decay=0,  # Adam options
                  # Gradient centralization on or off, applied to conv layers only or conv + fc layers
-                 use_gc=True, gc_conv_only=False, gc_loc=True
+                 use_gc=True, gc_conv_only=False, gc_loc=True,
+                 min_weight=-1000000.0, max_weight=1000000
                  ):
 
         # parameter checks
@@ -64,7 +65,7 @@ class Ranger(Optimizer):
         # prep defaults and init torch.optim base
         defaults = dict(lr=lr, alpha=alpha, k=k, step_counter=0, betas=betas,
                         N_sma_threshhold=N_sma_threshhold, eps=eps, weight_decay=weight_decay,
-                        gc_dim=None)
+                        min_weight=min_weight, max_weight=max_weight, gc_dim=None)
         super().__init__(params, defaults)
 
         # adjustable threshold
@@ -189,6 +190,12 @@ class Ranger(Optimizer):
                     G_grad = centralized_gradient(G_grad, use_gc=self.use_gc, gc_conv_only=self.gc_conv_only, dim=group['gc_dim'])
 
                 p_data_fp32.add_(G_grad, alpha=-step_size * group['lr'])
+
+                # constrain weights
+                min_weight = group['min_weight']
+                max_weight = group['max_weight']
+                p_data_fp32.clamp_(min_weight, max_weight)
+
                 p.data.copy_(p_data_fp32)
 
                 # integrated look ahead...

--- a/serialize.py
+++ b/serialize.py
@@ -6,6 +6,7 @@ import numpy
 import nnue_bin_dataset
 import struct
 import torch
+from torch import nn
 import pytorch_lightning as pl
 from torch.utils.data import DataLoader
 from functools import reduce
@@ -37,10 +38,11 @@ class NNUEWriter():
     self.write_header(model, fc_hash)
     self.int32(model.feature_set.hash ^ (M.L1*2)) # Feature transformer hash
     self.write_feature_transformer(model)
-    self.int32(fc_hash) # FC layers hash
-    self.write_fc_layer(model.l1)
-    self.write_fc_layer(model.l2)
-    self.write_fc_layer(model.output, is_output=True)
+    for l1, l2, output in model.layer_stacks.get_coalesced_layer_stacks():
+      self.int32(fc_hash) # FC layers hash
+      self.write_fc_layer(l1)
+      self.write_fc_layer(l2)
+      self.write_fc_layer(output, is_output=True)
 
   @staticmethod
   def fc_hash(model):
@@ -49,13 +51,13 @@ class NNUEWriter():
     prev_hash ^= (M.L1 * 2)
 
     # Fully connected layers
-    layers = [model.l1, model.l2, model.output]
+    layers = [model.layer_stacks.l1, model.layer_stacks.l2, model.layer_stacks.output]
     for layer in layers:
       layer_hash = 0xCC03DAE4
-      layer_hash += layer.out_features
+      layer_hash += layer.out_features // model.num_ls_buckets
       layer_hash ^= prev_hash >> 1
       layer_hash ^= (prev_hash << 31) & 0xFFFFFFFF
-      if layer.out_features != 1:
+      if layer.out_features // model.num_ls_buckets != 1:
         # Clipped ReLU hash
         layer_hash = (layer_hash + 0x538D24C7) & 0xFFFFFFFF
       prev_hash = layer_hash
@@ -81,7 +83,7 @@ class NNUEWriter():
 
     weight = self.coalesce_ft_weights(model, layer)
     weight0 = weight[:, :M.L1]
-    psqtweight0 = weight[:, M.L1]
+    psqtweight0 = weight[:, M.L1:]
     weight = weight0.mul(127).round().to(torch.int16)
     psqtweight = psqtweight0.mul(9600).round().to(torch.int32) # kPonanzaConstant * FV_SCALE = 9600
     ascii_hist('ft weight:', weight.numpy())
@@ -135,11 +137,21 @@ class NNUEReader():
 
     self.read_header(feature_set, fc_hash)
     self.read_int32(feature_set.hash ^ (M.L1*2)) # Feature transformer hash
-    self.read_feature_transformer(self.model.input)
-    self.read_int32(fc_hash) # FC layers hash
-    self.read_fc_layer(self.model.l1)
-    self.read_fc_layer(self.model.l2)
-    self.read_fc_layer(self.model.output, is_output=True)
+    self.read_feature_transformer(self.model.input, self.model.num_psqt_buckets)
+    for i in range(self.model.num_ls_buckets):
+      l1 = nn.Linear(2*M.L1, M.L2)
+      l2 = nn.Linear(M.L2, M.L3)
+      output = nn.Linear(M.L3, 1)
+      self.read_int32(fc_hash) # FC layers hash
+      self.read_fc_layer(l1)
+      self.read_fc_layer(l2)
+      self.read_fc_layer(output, is_output=True)
+      self.model.layer_stacks.l1.weight.data[i*M.L2:(i+1)*M.L2, :] = l1.weight
+      self.model.layer_stacks.l1.bias.data[i*M.L2:(i+1)*M.L2] = l1.bias
+      self.model.layer_stacks.l2.weight.data[i*M.L3:(i+1)*M.L3, :] = l2.weight
+      self.model.layer_stacks.l2.bias.data[i*M.L3:(i+1)*M.L3] = l2.bias
+      self.model.layer_stacks.output.weight.data[i:(i+1), :] = output.weight
+      self.model.layer_stacks.output.bias.data[i:(i+1)] = output.bias
 
   def read_header(self, feature_set, fc_hash):
     self.read_int32(VERSION) # version
@@ -153,13 +165,13 @@ class NNUEReader():
     d = d.reshape(shape)
     return d
 
-  def read_feature_transformer(self, layer):
-    bias = self.tensor(numpy.int16, [layer.bias.shape[0]-1]).divide(127.0)
-    layer.bias.data = torch.cat([bias, torch.tensor([0])])
+  def read_feature_transformer(self, layer, num_psqt_buckets):
+    bias = self.tensor(numpy.int16, [layer.bias.shape[0]-num_psqt_buckets]).divide(127.0)
+    layer.bias.data = torch.cat([bias, torch.tensor([0]*num_psqt_buckets)])
     # weights stored as [41024][256], so we need to transpose the pytorch [256][41024]
     shape = layer.weight.shape
-    weights = self.tensor(numpy.int16, [shape[0], shape[1]-1])
-    psqtweights = self.tensor(numpy.int32, [shape[0], 1])
+    weights = self.tensor(numpy.int16, [shape[0], shape[1]-num_psqt_buckets])
+    psqtweights = self.tensor(numpy.int32, [shape[0], num_psqt_buckets])
     weights = weights.divide(127.0)
     psqtweights = psqtweights.divide(9600.0)
     layer.weight.data = torch.cat([weights, psqtweights], dim=1)

--- a/serialize.py
+++ b/serialize.py
@@ -66,9 +66,7 @@ class NNUEWriter():
   def write_header(self, model, fc_hash):
     self.int32(VERSION) # version
     self.int32(fc_hash ^ model.feature_set.hash ^ (M.L1*2)) # halfkp network hash
-    description = b"Features=HalfKA(Friend)[49216->256x2],"
-    description += b"Network=AffineTransform[1<-32](ClippedReLU[32](AffineTransform[32<-32]"
-    description += b"(ClippedReLU[32](AffineTransform[32<-512](InputSlice[512(0:512)])))))"
+    description = b"Network trained with the https://github.com/glinscott/nnue-pytorch trainer."
     self.int32(len(description)) # Network definition
     self.buf.extend(description)
 

--- a/train.py
+++ b/train.py
@@ -75,7 +75,7 @@ def main():
 
   batch_size = args.batch_size
   if batch_size <= 0:
-    batch_size = 128 if args.gpus == 0 else 8192
+    batch_size = 16384
   print('Using batch size {}'.format(batch_size))
 
   print('Smart fen skipping: {}'.format(args.smart_fen_skipping))

--- a/train.py
+++ b/train.py
@@ -56,10 +56,12 @@ def main():
 
   if args.resume_from_model is None:
     nnue = M.NNUE(feature_set=feature_set, lambda_=args.lambda_)
+    nnue.cuda()
   else:
     nnue = torch.load(args.resume_from_model)
     nnue.set_feature_set(feature_set)
     nnue.lambda_ = args.lambda_
+    nnue.cuda()
 
   print("Feature set: {}".format(feature_set.name))
   print("Num real features: {}".format(feature_set.num_real_features))

--- a/train.py
+++ b/train.py
@@ -41,8 +41,9 @@ def main():
   parser.add_argument("--batch-size", default=-1, type=int, dest='batch_size', help="Number of positions per batch / per iteration. Default on GPU = 8192 on CPU = 128.")
   parser.add_argument("--threads", default=-1, type=int, dest='threads', help="Number of torch threads to use. Default automatic (cores) .")
   parser.add_argument("--seed", default=42, type=int, dest='seed', help="torch seed to use.")
-  parser.add_argument("--smart-fen-skipping", action='store_true', dest='smart_fen_skipping', help="If enabled positions that are bad training targets will be skipped during loading. Default: False")
-  parser.add_argument("--random-fen-skipping", default=0, type=int, dest='random_fen_skipping', help="skip fens randomly on average random_fen_skipping before using one.")
+  parser.add_argument("--smart-fen-skipping", action='store_true', dest='smart_fen_skipping_deprecated', help="If enabled positions that are bad training targets will be skipped during loading. Default: True, kept for backwards compatibility. This option is ignored")
+  parser.add_argument("--no-smart-fen-skipping", action='store_true', dest='no_smart_fen_skipping', help="If used then no smart fen skipping will be done. By default smart fen skipping is done.")
+  parser.add_argument("--random-fen-skipping", default=3, type=int, dest='random_fen_skipping', help="skip fens randomly on average random_fen_skipping before using one.")
   parser.add_argument("--resume-from-model", dest='resume_from_model', help="Initializes training using the weights from the given .pt model")
   features.add_argparse_args(parser)
   args = parser.parse_args()
@@ -78,7 +79,7 @@ def main():
     batch_size = 16384
   print('Using batch size {}'.format(batch_size))
 
-  print('Smart fen skipping: {}'.format(args.smart_fen_skipping))
+  print('Smart fen skipping: {}'.format(not args.no_smart_fen_skipping))
   print('Random fen skipping: {}'.format(args.random_fen_skipping))
 
   if args.threads > 0:
@@ -99,7 +100,7 @@ def main():
     train, val = data_loader_py(args.train, args.val, feature_set, batch_size, main_device)
   else:
     print('Using c++ data loader')
-    train, val = data_loader_cc(args.train, args.val, feature_set, args.num_workers, batch_size, args.smart_fen_skipping, args.random_fen_skipping, main_device)
+    train, val = data_loader_cc(args.train, args.val, feature_set, args.num_workers, batch_size, not args.no_smart_fen_skipping, args.random_fen_skipping, main_device)
 
   trainer.fit(nnue, train, val)
 

--- a/training_data_loader.cpp
+++ b/training_data_loader.cpp
@@ -194,6 +194,69 @@ struct HalfKAFactorized {
     }
 };
 
+struct HalfKAv2 {
+    static constexpr int NUM_SQ = 64;
+    static constexpr int NUM_PT = 11;
+    static constexpr int NUM_PLANES = NUM_SQ * NUM_PT;
+    static constexpr int INPUTS = NUM_PLANES * NUM_SQ;
+
+    static constexpr int MAX_ACTIVE_FEATURES = 32;
+
+    static int feature_index(Color color, Square ksq, Square sq, Piece p)
+    {
+        auto p_idx = static_cast<int>(p.type()) * 2 + (p.color() != color);
+        if (p_idx == 11)
+            --p_idx; // pack the opposite king into the same NUM_SQ * NUM_SQ
+        return static_cast<int>(orient_flip(color, sq)) + p_idx * NUM_SQ + static_cast<int>(ksq) * NUM_PLANES;
+    }
+
+    static std::pair<int, int> fill_features_sparse(const TrainingDataEntry& e, int* features, float* values, Color color)
+    {
+        auto& pos = e.pos;
+        auto pieces = pos.piecesBB();
+        auto ksq = pos.kingSquare(color);
+
+        int j = 0;
+        for(Square sq : pieces)
+        {
+            auto p = pos.pieceAt(sq);
+            values[j] = 1.0f;
+            features[j] = feature_index(color, orient_flip(color, ksq), sq, p);
+            ++j;
+        }
+
+        return { j, INPUTS };
+    }
+};
+
+struct HalfKAv2Factorized {
+    // Factorized features
+    static constexpr int PIECE_INPUTS = HalfKAv2::NUM_SQ * HalfKAv2::NUM_PT;
+    static constexpr int INPUTS = HalfKAv2::INPUTS + PIECE_INPUTS;
+
+    static constexpr int MAX_PIECE_FEATURES = 32;
+    static constexpr int MAX_ACTIVE_FEATURES = HalfKAv2::MAX_ACTIVE_FEATURES + MAX_PIECE_FEATURES;
+
+    static std::pair<int, int> fill_features_sparse(const TrainingDataEntry& e, int* features, float* values, Color color)
+    {
+        const auto [start_j, offset] = HalfKAv2::fill_features_sparse(e, features, values, color);
+        auto& pos = e.pos;
+        auto pieces = pos.piecesBB();
+
+        int j = start_j;
+        for(Square sq : pieces)
+        {
+            auto p = pos.pieceAt(sq);
+            auto p_idx = static_cast<int>(p.type()) * 2 + (p.color() != color);
+            values[j] = 1.0f;
+            features[j] = offset + (p_idx * HalfKAv2::NUM_SQ) + static_cast<int>(orient_flip(color, sq));
+            ++j;
+        }
+
+        return { j, INPUTS };
+    }
+};
+
 template <typename T, typename... Ts>
 struct FeatureSet
 {
@@ -512,6 +575,14 @@ extern "C" {
         {
             return new SparseBatch(FeatureSet<HalfKAFactorized>{}, entries);
         }
+        else if (feature_set == "HalfKAv2")
+        {
+            return new SparseBatch(FeatureSet<HalfKAv2>{}, entries);
+        }
+        else if (feature_set == "HalfKAv2^")
+        {
+            return new SparseBatch(FeatureSet<HalfKAv2Factorized>{}, entries);
+        }
         fprintf(stderr, "Unknown feature_set %s\n", feature_set_c);
         return nullptr;
     }
@@ -558,6 +629,14 @@ extern "C" {
         else if (feature_set == "HalfKA^")
         {
             return new FeaturedBatchStream<FeatureSet<HalfKAFactorized>, SparseBatch>(concurrency, filename, batch_size, cyclic, skipPredicate);
+        }
+        else if (feature_set == "HalfKAv2")
+        {
+            return new FeaturedBatchStream<FeatureSet<HalfKAv2>, SparseBatch>(concurrency, filename, batch_size, cyclic, skipPredicate);
+        }
+        else if (feature_set == "HalfKAv2^")
+        {
+            return new FeaturedBatchStream<FeatureSet<HalfKAv2Factorized>, SparseBatch>(concurrency, filename, batch_size, cyclic, skipPredicate);
         }
         fprintf(stderr, "Unknown feature_set %s\n", feature_set_c);
         return nullptr;

--- a/training_data_loader.cpp
+++ b/training_data_loader.cpp
@@ -224,6 +224,8 @@ struct SparseBatch
         black = new int[size * FeatureSet<Ts...>::MAX_ACTIVE_FEATURES];
         white_values = new float[size * FeatureSet<Ts...>::MAX_ACTIVE_FEATURES];
         black_values = new float[size * FeatureSet<Ts...>::MAX_ACTIVE_FEATURES];
+        psqt_indices = new int[size];
+        layer_stack_indices = new int[size];
 
         num_active_white_features = 0;
         num_active_black_features = 0;
@@ -257,6 +259,8 @@ struct SparseBatch
     int* black;
     float* white_values;
     float* black_values;
+    int* psqt_indices;
+    int* layer_stack_indices;
 
     ~SparseBatch()
     {
@@ -267,6 +271,8 @@ struct SparseBatch
         delete[] black;
         delete[] white_values;
         delete[] black_values;
+        delete[] psqt_indices;
+        delete[] layer_stack_indices;
     }
 
 private:
@@ -277,6 +283,8 @@ private:
         is_white[i] = static_cast<float>(e.pos.sideToMove() == Color::White);
         outcome[i] = (e.result + 1.0f) / 2.0f;
         score[i] = e.score;
+        psqt_indices[i] = (e.pos.piecesBB().count() - 1) / 4;
+        layer_stack_indices[i] = psqt_indices[i];
         fill_features(FeatureSet<Ts...>{}, i, e);
     }
 

--- a/visualize.py
+++ b/visualize.py
@@ -33,11 +33,13 @@ class NNUEVisualizer():
     def plot_input_weights(self):
         # Coalesce weights and transform them to Numpy domain.
         weights = M.coalesce_ft_weights(self.model, self.model.input)
+        weights = weights[:, :M.L1]
         weights = weights.flatten().numpy()
 
         if self.args.ref_model:
             ref_weights = M.coalesce_ft_weights(
                 self.ref_model, self.ref_model.input)
+            ref_weights = ref_weights[:, :M.L1]
             ref_weights = ref_weights.flatten().numpy()
             weights -= ref_weights
 
@@ -75,7 +77,7 @@ class NNUEVisualizer():
         # Derived/fixed constants.
         numy = hd//numx
         widthx = 128
-        widthy = 304
+        widthy = 400
         totalx = numx * widthx
         totaly = numy * widthy
         totaldim = totalx*totaly
@@ -88,13 +90,13 @@ class NNUEVisualizer():
             weights_mask = []
             for j in range(0, weights.size, hd):
                 # Calculate piece and king placement.
-                pi = (j // hd - 1) % 641
-                ki = (j // hd - 1) // 641
+                pi = (j // hd) % 704
+                ki = (j // hd) // 704
                 piece = pi // 64
                 rank = (pi % 64) // 8
 
-                if pi == 640 or ((rank == 0 or rank == 7) and (piece == 0 or piece == 1)):
-                    # Ignore unused weights for "Shogi piece drop" and pawns on first/last rank.
+                if ((rank == 0 or rank == 7) and (piece == 0 or piece == 1)):
+                    # Ignore unused weights for pawns on first/last rank.
                     continue
 
                 kipos = [ki % 8, ki // 8]
@@ -457,7 +459,7 @@ def main():
     features.add_argparse_args(parser)
     args = parser.parse_args()
 
-    supported_features = ('HalfKP', 'HalfKP^')
+    supported_features = ('HalfKAv2', 'HalfKAv2^')
     assert args.features in supported_features
     feature_set = features.get_feature_set_from_name(args.features)
 
@@ -491,8 +493,8 @@ def main():
     visualizer = NNUEVisualizer(model, ref_model, args)
 
     visualizer.plot_input_weights()
-    visualizer.plot_fc_weights()
-    visualizer.plot_biases()
+    #visualizer.plot_fc_weights()
+    #visualizer.plot_biases()
 
     if not args.dont_show:
         plt.show()


### PR DESCRIPTION
This is a slightly cleaned up version of https://github.com/Sopel97/nnue-pytorch/tree/experiment_56, with a few changes:

- weight clipping is moved outside of the optimizer, should behave about the same
- updated visualize.py to at least work, though it doesn't visualize fc layers and the plot for ft weights is slightly off
- updated cross_eval_check.py
- updated perf_sigmoid_fitter.py
- changed LR scheduling based on further results

Now will follow results from individual changes. The separate graphs are not comparable between each other.

- weight clipping 
![plot_14_15](https://user-images.githubusercontent.com/8037982/118631761-18145b80-b7d0-11eb-807b-42503544e753.png)
- per psqt features 
![plot_20_21](https://user-images.githubusercontent.com/8037982/118631033-683eee00-b7cf-11eb-98e2-bc82af30fa2e.png)
- 8 subnets and psqt buckets 
![plot_21_30](https://user-images.githubusercontent.com/8037982/118631200-8b699d80-b7cf-11eb-93c6-fabc782d8698.png)
- MSE over WDL-space evals (not very visible on the graph, but the trend was 3 elo better. Loss not comparable)
![plot_48_49](https://user-images.githubusercontent.com/8037982/118631887-367a5700-b7d0-11eb-83ae-cce7608421be.png)
- disable GC (lower loss)
![plot_53_54](https://user-images.githubusercontent.com/8037982/118632065-5d388d80-b7d0-11eb-92fb-0bd5c3967c02.png)
- drop LR by 0.987 every epoch (trend ~2 elo better, easier parametrization) 
![plot_56_57](https://user-images.githubusercontent.com/8037982/118632249-835e2d80-b7d0-11eb-8859-5d531a7db391.png)

The new architecture diagram:
![HalfKAv2-45056-512x2P8x2 -16-32-1 x8](https://user-images.githubusercontent.com/8037982/118657052-66832380-b7eb-11eb-95a9-030936e30522.png)





