### PR TITLE
Fix the reported size of the HalfKAv2Factorized feature set.

### DIFF
--- a/training_data_loader.cpp
+++ b/training_data_loader.cpp
@@ -231,7 +231,8 @@ struct HalfKAv2 {
 
 struct HalfKAv2Factorized {
     // Factorized features
-    static constexpr int PIECE_INPUTS = HalfKAv2::NUM_SQ * HalfKAv2::NUM_PT;
+    static constexpr int NUM_PT = 12;
+    static constexpr int PIECE_INPUTS = HalfKAv2::NUM_SQ * NUM_PT;
     static constexpr int INPUTS = HalfKAv2::INPUTS + PIECE_INPUTS;
 
     static constexpr int MAX_PIECE_FEATURES = 32;


### PR DESCRIPTION
Non-functional, but might be relevant in the future. The value is currently unused.