### PR TITLE
Add a way to disable factorization

### DIFF
--- a/model.py
+++ b/model.py
@@ -5,6 +5,7 @@ import torch.nn.functional as F
 import pytorch_lightning as pl
 import copy
 from feature_transformer import DoubleFeatureTransformerSlice
+from optimizer import NnueOptimizer
 
 # 3 layer fully connected network
 L1 = 512
@@ -307,7 +308,7 @@ class NNUE(pl.LightningModule):
       {'params' : [self.layer_stacks.output.bias], 'lr' : LR / 10 },
     ]
     # increasing the eps leads to less saturated nets with a few dead neurons
-    optimizer = ranger.Ranger(train_params, betas=(.9, 0.999), eps=1.0e-7, gc_loc=False, use_gc=False)
+    optimizer = NnueOptimizer(ranger.Ranger, train_params, betas=(.9, 0.999), eps=1.0e-7, gc_loc=False, use_gc=False)
     # Drop learning rate after 75 epochs
     scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=1, gamma=0.987)
     return [optimizer], [scheduler]

--- a/optimizer.py
+++ b/optimizer.py
@@ -1,0 +1,81 @@
+from torch.optim.optimizer import Optimizer, required
+import torch
+
+def NnueOptimizer(optimizer_cls, params, **kwargs):
+    class SpecificNnueOptimizer(optimizer_cls):
+        def __init__(self, params, **kwargs):
+            super().__init__(params, **kwargs)
+
+            self.state['nnue_optimizer']['num_finished_steps'] = 0
+            self.post_step_callback = None
+
+            self._add_default('maskable', False)
+
+
+
+        def set_post_step_callback(self, callback):
+            self.post_step_callback = callback
+
+
+
+        def get_num_finished_steps(self):
+            return self.state['nnue_optimizer']['num_finished_steps']
+
+
+
+        def freeze_parameter_region(self, param, indices):
+            if len(indices) != len(param.shape):
+                raise Exception('Invalid indices for parameter region.')
+
+            if param not in self.state:
+                raise Exception('No state for parameter.')
+
+            state = self.state[param]
+
+            if 'weight_mask' not in state:
+                raise Exception('Parameter not masked.')
+
+            state['weight_mask'][indices].fill_(0.0)
+
+
+
+        def step(self, closure=None):
+            loss = super(SpecificNnueOptimizer, self).step(closure)
+
+            for group in self.param_groups:
+                for p in group['params']:
+                    state = self.state[p]  # get state dict for this param
+
+                    if not 'nnue_optimizer_initialized' in state:
+                        state['nnue_optimizer_initialized'] = True
+
+                        if group['maskable']:
+                            state['weight_mask'] = torch.ones_like(p)
+
+                    if 'weight_mask' in state:
+                        p.data.mul_(state['weight_mask'])
+
+            self.state['nnue_optimizer']['num_finished_steps'] += 1
+
+            if self.post_step_callback is not None:
+                self.post_step_callback(self)
+
+            return loss
+
+
+
+        def _add_default(self, default_name, default_value):
+            if default_name in self.defaults:
+                raise Exception('Default already exists.')
+
+            self.defaults[default_name] = default_value
+
+            for group in self.param_groups:
+                if default_value is required and not default_name in group:
+                    raise ValueError("parameter group didn't specify a value of required optimization parameter " + name)
+                else:
+                    group.setdefault(default_name, default_value)
+
+
+
+    return SpecificNnueOptimizer(params, **kwargs)


### PR DESCRIPTION
This patch adds a way to disable factorization of the L1 and the FT layer. Currently it's only possible from the code, with no option exposed to the user. A wrapper is introduced for the optimizer to handle partial layer masks; in the future weight clipping should be moved there.