### PR TITLE
Add a script for finding most important [FT] weights in a net.

### DIFF
--- a/weight_importance.py
+++ b/weight_importance.py
@@ -1,0 +1,127 @@
+import argparse
+import chess
+import features
+import model as M
+import numpy as np
+import torch
+import nnue_dataset
+import matplotlib.pyplot as plt
+from matplotlib.gridspec import GridSpec
+
+from serialize import NNUEReader
+
+def load_model(filename, feature_set):
+    if filename.endswith(".pt") or filename.endswith(".ckpt"):
+        if filename.endswith(".pt"):
+            model = torch.load(filename)
+        else:
+            model = M.NNUE.load_from_checkpoint(
+                filename, feature_set=feature_set)
+        model.eval()
+    elif filename.endswith(".nnue"):
+        with open(filename, 'rb') as f:
+            reader = NNUEReader(f, feature_set)
+        model = reader.model
+    else:
+        raise Exception("Invalid filetype: " + str(filename))
+
+    return model
+
+def do_forward_backward(model, batch, device):
+    us, them, white_indices, white_values, black_indices, black_values, outcome, score, psqt_indices, layer_stack_indices = batch
+
+    model.zero_grad()
+    res = model.forward(us, them, white_indices, white_values, black_indices, black_values, psqt_indices, layer_stack_indices)
+    res.backward()
+
+def get_ft_weight_importance(model, dataset, pos_n, device):
+    dataset_iter = iter(dataset)
+    tot_g = None
+    for i in range(pos_n):
+        batch = next(dataset_iter)
+        do_forward_backward(model, batch, device)
+        g = model.input.weight.grad[:, :M.L1].detach()
+        g = torch.abs(g)
+        if tot_g is None:
+            tot_g = g
+        else:
+            tot_g += g
+
+        if (i + 1) % 100 == 0:
+            print('Done {} out of {} evaluations...'.format(i+1, pos_n))
+
+    tot_g = tot_g.flatten()
+    val, ind = torch.sort(tot_g, descending=True)
+    return ind, val
+
+def process_ft_weight_importance(ind, val, best_n, best_pct):
+    res = []
+    rs = 0.0
+    s = torch.sum(val)
+    size = ind.shape[0]
+    for i in range(size):
+        x = ind[i]
+        v = val[i]
+        if i > best_n:
+            break
+        if rs > s * best_pct:
+            break
+        res.append((x//M.L1, x%M.L1, v))
+        rs += v
+    return res
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Finds weights with the highest importance. Importance is measured by the absolute value of the gradient.")
+    parser.add_argument(
+        "model", help="Source model (can be .ckpt, .pt or .nnue)")
+    parser.add_argument(
+        "--best_n", type=int, default=256,
+        help="Get only n most important weights")
+    parser.add_argument(
+        "--best_pct", type=float, default=1.0,
+        help="Get only weights up to a given % [0, 1] of the total importance. Whichever of best_n or best_pct is reached faster.")
+    parser.add_argument(
+        "--pos_n", type=int, default=1024,
+        help="The number of positions to evaluate.")
+    parser.add_argument(
+        "--layer", type=str, default="ft",
+        help="The layer to probe. Currently only 'ft' is supported.")
+    parser.add_argument(
+        "--output", type=str,
+        help="Optional output file.")
+    parser.add_argument("--data", type=str,
+        help="path to a .bin or .binpack dataset")
+    features.add_argparse_args(parser)
+    args = parser.parse_args()
+
+    assert args.layer == "ft"
+
+    supported_features = ('HalfKAv2', 'HalfKAv2_hm')
+    assert args.features in supported_features
+    feature_set = features.get_feature_set_from_name(args.features)
+
+    main_device = 'cuda'
+    model = load_model(args.model, feature_set)
+    model.to(device=main_device)
+    dataset = nnue_dataset.SparseBatchDataset(feature_set.name, args.data, 1, num_workers=1,
+                                              filtered=True, random_fen_skipping=32, device=main_device)
+
+    file = None
+    if args.output:
+        file = open(args.output, 'w')
+
+    if args.layer == "ft":
+        ind, val = get_ft_weight_importance(model=model, dataset=dataset, pos_n=args.pos_n, device=main_device)
+        result = process_ft_weight_importance(ind, val, best_n=args.best_n, best_pct=args.best_pct)
+        for i, (x, y, v) in enumerate(result):
+            msg = '{}\t{}\t{}'.format(x, y, v)
+            print(msg)
+            if file is not None:
+                file.write(msg + '\n')
+
+    if file:
+        file.close()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This script provides a way to find most important (currently only for the feature transformer) weights in a given network under given dataset. The importance is determined by taking a sum of absolute values of the gradients. Because it is not possible to accumulate absolute values of the gradients over a batch this process needs to be done with batch size of 1, which means it's relatively slow. `pos_n` of several 10s or 100s of thousands should be feasible however. This tool is supposed to help with choosing weights for SPSA tuning.

```
usage: weight_importance.py [-h] [--best_n BEST_N] [--best_pct BEST_PCT]
                            [--pos_n POS_N] [--layer LAYER] [--output OUTPUT]
                            [--data DATA] [--features FEATURES]
                            model

Finds weights with the highest importance. Importance is measured by the
absolute value of the gradient.

positional arguments:
  model                Source model (can be .ckpt, .pt or .nnue)

optional arguments:
  -h, --help           show this help message and exit
  --best_n BEST_N      Get only n most important weights
  --best_pct BEST_PCT  Get only weights up to a given percent [0, 1] of the
                       total importance. Whichever of best_n or best_pct is
                       reached faster.
  --pos_n POS_N        The number of positions to evaluate.
  --layer LAYER        The layer to probe. Currently only 'ft' is supported.
  --output OUTPUT      Optional output file.
  --data DATA          path to a .bin or .binpack dataset
  --features FEATURES  The feature set to use. Can be a union of feature
                       blocks (for example P+HalfKP). "^" denotes a factorized
                       block. Currently available feature blocks are: HalfKP,
                       HalfKP^, HalfKA, HalfKA^, HalfKAv2, HalfKAv2^,
                       HalfKAv2_hm, HalfKAv2_hm^
```

The produced output can be optionally also saved to a file by using `--output` option to provide the path to the file. The output format is `{feature_index}\t{output_index}\t{total_grad}`.

Example from a small HalfKAv2_hm-128x2-8-32-1 net:
```
C:\dev\nnue-pytorch>python weight_importance.py --data=d10_10000.bin --features=
HalfKAv2_hm --pos_n=1024 --best_n=32 --output=out.txt nn.nnue
Done 100 out of 1024 evaluations...
Done 200 out of 1024 evaluations...
Done 300 out of 1024 evaluations...
Done 400 out of 1024 evaluations...
Done 500 out of 1024 evaluations...
Done 600 out of 1024 evaluations...
Done 700 out of 1024 evaluations...
Done 800 out of 1024 evaluations...
Done 900 out of 1024 evaluations...
Done 1000 out of 1024 evaluations...
22468   81      22.95361328125
21062   1       19.015615463256836
21833   81      16.794130325317383
22468   1       16.653770446777344
22468   19      16.062719345092773
22468   52      15.507932662963867
22468   37      15.23114013671875
22468   75      15.099000930786133
22468   103     14.928569793701172
21062   52      14.71535873413086
21062   19      14.61031436920166
22215   81      14.525751113891602
22468   72      14.388435363769531
22468   110     14.307860374450684
22468   70      14.287771224975586
21062   37      14.226285934448242
21062   81      14.158844947814941
22468   119     13.891007423400879
22468   88      13.868194580078125
21062   103     13.766294479370117
22468   31      13.745142936706543
22208   81      13.659659385681152
21832   81      13.514847755432129
21062   110     13.416680335998535
22468   8       13.376480102539062
22468   44      13.148722648620605
21062   31      13.105257987976074
22328   81      13.007036209106445
21062   75      12.977574348449707
22468   3       12.970292091369629
21837   81      12.898788452148438
21062   8       12.8389310836792
21838   81      12.642690658569336
```
