### PR TITLE
Skip positions to target a distribution

### DIFF
--- a/training_data_loader.cpp
+++ b/training_data_loader.cpp
@@ -819,6 +819,29 @@ std::function<bool(const TrainingDataEntry&)> make_skip_predicate(bool filtered,
             wld_filtered
             ](const TrainingDataEntry& e){
 
+            static constexpr double desired_piece_count_weights[33] = {
+1.000000, 1.121094, 1.234375, 1.339844, 1.437500, 1.527344, 1.609375, 1.683594, 1.750000, 1.808594, 1.859375, 1.902344, 1.937500, 1.964844, 1.984375, 1.996094, 2.000000, 1.996094, 1.984375, 1.964844, 1.937500, 1.902344, 1.859375, 1.808594, 1.750000, 1.683594, 1.609375, 1.527344, 1.437500, 1.339844, 1.234375, 1.121094, 1.000000
+            };
+
+            static constexpr double desired_piece_count_weights_total = [](){
+                double tot = 0;
+                for (auto w : desired_piece_count_weights)
+                    tot += w;
+                return tot;
+            }();
+
+            static thread_local std::mt19937 gen(std::random_device{}());
+
+            // keep stats on passing pieces
+            static thread_local double alpha = 1;
+            static thread_local double piece_count_history_all[33] = {0};
+            static thread_local double piece_count_history_passed[33] = {0};
+            static thread_local double piece_count_history_all_total = 0;
+            static thread_local double piece_count_history_passed_total = 0;
+
+            // max skipping rate
+            static constexpr double max_skipping_rate = 15.0;
+
             auto do_wld_skip = [&]() {
                 std::bernoulli_distribution distrib(1.0 - e.score_result_prob());
                 auto& prng = rng::get_thread_local_rng();
@@ -835,8 +858,57 @@ std::function<bool(const TrainingDataEntry&)> make_skip_predicate(bool filtered,
                 return (e.isCapturingMove() || e.isInCheck());
             };
 
-            static thread_local std::mt19937 gen(std::random_device{}());
-            return (random_fen_skipping && do_skip()) || (filtered && do_filter()) || (wld_filtered && do_wld_skip());
+            if (random_fen_skipping && do_skip())
+                return true;
+
+            if (filtered && do_filter())
+                return true;
+
+            if (wld_filtered && do_wld_skip())
+                return true;
+
+            constexpr bool do_debug_print = false;
+            if (do_debug_print) {
+                if (uint64_t(piece_count_history_all_total) % 10000 == 0) {
+                    std::cout << "Total : " << piece_count_history_all_total << '\n';
+                    std::cout << "Passed: " << piece_count_history_passed_total << '\n';
+                    for (int i = 0; i < 33; ++i)
+                        std::cout << i << ' ' << piece_count_history_passed[i] << '\n';
+                }
+            }
+
+            const int pc = e.pos.piecesBB().count();
+            piece_count_history_all[pc] += 1;
+            piece_count_history_all_total += 1;
+
+            // update alpha, which scales the filtering probability, to a maximum rate.
+            if (uint64_t(piece_count_history_all_total) % 10000 == 0) {
+                double pass = piece_count_history_all_total * desired_piece_count_weights_total;
+                for (int i = 0; i < 33; ++i)
+                {
+                    if (desired_piece_count_weights[pc] > 0)
+                    {
+                        double tmp = piece_count_history_all_total * desired_piece_count_weights[pc] /
+                                     (desired_piece_count_weights_total * piece_count_history_all[pc]);
+                        if (tmp < pass)
+                            pass = tmp;
+                    }
+                }
+                alpha = 1.0 / (pass * max_skipping_rate);
+            }
+
+            double tmp = alpha *  piece_count_history_all_total * desired_piece_count_weights[pc] /
+                                 (desired_piece_count_weights_total * piece_count_history_all[pc]);
+            tmp = std::min(1.0, tmp);
+            std::bernoulli_distribution distrib(1.0 - tmp);
+            auto& prng = rng::get_thread_local_rng();
+            if (distrib(prng))
+                return true;
+
+            piece_count_history_passed[pc] += 1;
+            piece_count_history_passed_total += 1;
+
+            return false;
         };
     }
 


### PR DESCRIPTION
skips positions to target a prescribed distribution of positions with number of pieces.

Uses i*(32-i)/(16*16)+1

Introduces a max skipping factor of 15.

Needs some further work to make this optional and more flexible.