### PR TITLE
Fix binpack reader thread buffer utilization.

### DIFF
--- a/lib/nnue_training_data_formats.h
+++ b/lib/nnue_training_data_formats.h
@@ -7587,7 +7587,7 @@ namespace binpack
 
                 while(!isEnd && !m_stopFlag.load())
                 {
-                    for (std::size_t i = 0; i < threadBufferSize; ++i)
+                    while (m_localBuffer.size() < threadBufferSize)
                     {
                         if (m_movelistReader.has_value())
                         {


### PR DESCRIPTION
Spotted recently. Utilization depended on skipping because we used an indepndent counter instead of buffer size. This might impact other performance issues.