### PR TITLE
Fix the incorrect weight scale used in NNUEReader

### DIFF
--- a/serialize.py
+++ b/serialize.py
@@ -190,8 +190,12 @@ class NNUEReader():
     layer.weight.data = torch.cat([weights, psqt_weights], dim=1)
 
   def read_fc_layer(self, layer, is_output=False):
-    kWeightScale = self.model.weight_scale_out if is_output else self.model.weight_scale_hidden
-    kBiasScale = self.model.weight_scale_out * self.model.nnue2score if is_output else self.model.weight_scale_hidden * self.model.quantized_one
+    kWeightScaleHidden = self.model.weight_scale_hidden
+    kWeightScaleOut = self.model.nnue2score * self.model.weight_scale_out / self.model.quantized_one
+    kWeightScale = kWeightScaleOut if is_output else kWeightScaleHidden
+    kBiasScaleOut = self.model.weight_scale_out * self.model.nnue2score
+    kBiasScaleHidden = self.model.weight_scale_hidden * self.model.quantized_one
+    kBiasScale = kBiasScaleOut if is_output else kBiasScaleHidden
     kMaxWeight = self.model.quantized_one / kWeightScale
 
     # FC inputs are padded to 32 elements by spec.


### PR DESCRIPTION
It seems that an incorrect weight scale for output fc layers is used in NNUEReader, which causes a broken pt converted from a nnue file:

https://github.com/glinscott/nnue-pytorch/blob/77d79192877513878adc38aa4a3e9ce681be5f7f/serialize.py#L193-L195

According to NNUEWriter, this should be: 

https://github.com/glinscott/nnue-pytorch/blob/77d79192877513878adc38aa4a3e9ce681be5f7f/serialize.py#L102-L109
