### PR TITLE
Fix the incorrect NUM_PT in HalfKAv2_hmFactorized

### DIFF
--- a/training_data_loader.cpp
+++ b/training_data_loader.cpp
@@ -318,7 +318,8 @@ struct HalfKAv2_hm {
 
 struct HalfKAv2_hmFactorized {
     // Factorized features
-    static constexpr int PIECE_INPUTS = HalfKAv2_hm::NUM_SQ * HalfKAv2_hm::NUM_PT;
+    static constexpr int NUM_PT = 12;
+    static constexpr int PIECE_INPUTS = HalfKAv2_hm::NUM_SQ * NUM_PT;
     static constexpr int INPUTS = HalfKAv2_hm::INPUTS + PIECE_INPUTS;
 
     static constexpr int MAX_PIECE_FEATURES = 32;


### PR DESCRIPTION
Fixed the incorrect NUM_PT bug, as mentioned by @Pikacat-OuO in SF discord [here](https://discord.com/channels/435943710472011776/733545871911813221/1029376219415851018).