### PR TITLE
Fix Trainer.root_gpu crash when using pytorch-lightning 1.8+

### DIFF
--- a/train.py
+++ b/train.py
@@ -126,7 +126,7 @@ def main():
   checkpoint_callback = pl.callbacks.ModelCheckpoint(save_last=args.save_last_network, every_n_epochs=args.network_save_period, save_top_k=-1)
   trainer = pl.Trainer.from_argparse_args(args, callbacks=[checkpoint_callback], logger=tb_logger)
 
-  main_device = trainer.root_device if trainer.root_gpu is None else 'cuda:' + str(trainer.root_gpu)
+  main_device = trainer.root_device if trainer.strategy.root_device.index is None else 'cuda:' + str(trainer.strategy.root_device.index)
 
   nnue.to(device=main_device)
 


### PR DESCRIPTION
Fixes a crash upon training start when newer versions of pytorch-lightning are used due to `Trainer.root_gpu` being removed in 1.8+ a few weeks ago.

```
AttributeError: `Trainer.root_gpu` was deprecated in v1.6 and is no longer
accessible as of v1.8. Please use `Trainer.strategy.root_device.index` instead.
```

Support for `Trainer.root_gpu` was removed in:
https://github.com/Lightning-AI/lightning/issues/11994

More info about pytorch-lightning 1.8.0 in the release notes:
https://github.com/Lightning-AI/lightning/releases/tag/1.8.0

Fixes https://github.com/glinscott/nnue-pytorch/issues/212