### PR TITLE
Fix warnings about thread.setDaemon() in python 3.10+

### DIFF
--- a/scripts/easy_train.py
+++ b/scripts/easy_train.py
@@ -313,7 +313,7 @@ def schedule_exit(timeout_seconds, errcode):
         os._exit(errcode)
 
     thread = Thread(target=f)
-    thread.setDaemon(True)
+    thread.daemon = True
     thread.start()
 
 if sys.platform == "win32":
@@ -499,7 +499,7 @@ class SystemResourcesMonitor(Thread):
         self._running = True
         self._update()
 
-        self.setDaemon(True)
+        self.daemon = True
         self.start()
 
     def _update(self):
@@ -2410,7 +2410,7 @@ def spawn_training_watcher(training_runs, exit_timeout_after_finished):
             time.sleep(1)
 
     thread = Thread(target=f)
-    thread.setDaemon(True)
+    thread.daemon = True
     thread.start()
 
 def main():


### PR DESCRIPTION
camelCase methods in threading were deprecated in: https://github.com/python/cpython/pull/25174

```
easy_train.py:316: DeprecationWarning: setDaemon() is deprecated,
set the daemon attribute instead thread.setDaemon(True)
```

