### PR TITLE
Align column text when writing ordo tables to improve readability

### DIFF
--- a/run_games.py
+++ b/run_games.py
@@ -257,12 +257,17 @@ def run_approximate_ordo(root_dir):
 
     with open(ordo_file_name_temp, 'w') as ordo_file:
         ordo_file.write('\n')
-        ordo_file.write('   # PLAYER                        :  RATING  ERROR  POINTS  PLAYED   (%)\n')
+        ordo_file.write('    # PLAYER                     :  RATING  ERROR    POINTS  PLAYED  (%)\n')
         for i, entry in enumerate(entries_ordered):
             if entry.name == 'master':
-                ordo_file.write(f'   {i+1} {entry.name} : 0.0 ---- {entry.points:0.1f} {entry.total_games} {entry.performance*100:0.0f}\n')
+                entry_elo = '  0.0'
+                entry_elo_error_95 = '----'
             else:
-                ordo_file.write(f'   {i+1} {entry.name} : {entry.elo:0.1f} {entry.elo_error_95:0.1f} {entry.points:0.1f} {entry.total_games} {entry.performance*100:0.0f}\n')
+                entry_elo = f'{entry.elo:0.1f}'
+                entry_elo_error_95 = f'{entry.elo_error_95:0.1f}'
+            entry_points = f'{entry.points:0.1f}'
+            entry_performance = f'{entry.performance*100:0.0f}'
+            ordo_file.write(f'   {i+1:2} {entry.name:<26} : {entry_elo:>7} {entry_elo_error_95:>6} {entry_points:>9} {entry.total_games:>7} {entry_performance:>4}\n')
         ordo_file.write('\n')
 
     if not os.path.exists(ordo_file_name):


### PR DESCRIPTION
Improves readability by aligning the text in each row with table headers. Numbers are right-aligned to line up the decimals. Player names are left-aligned. Table parsing works the same as before since only whitespace was modified and the text is all the same.

Before:
```
# PLAYER                        :  RATING  ERROR  POINTS  PLAYED   (%)
1 run_6/nn-epoch539.nnue : 1.7 5.4 2713.5 5400 50
2 run_5/nn-epoch579.nnue : 0.7 6.7 1803.5 3600 50
3 master : 0.0 ---- 722906.5 1384200 52
4 run_11/nn-epoch559.nnue : -0.3 5.4 2698.0 5400 50
5 run_5/nn-epoch499.nnue : -0.9 4.7 3590.5 7200 50
```

After:
```
# PLAYER                     :  RATING  ERROR    POINTS  PLAYED  (%)
1 master                     :     0.0   ----   55579.0  103680   54
2 run_0/nn-epoch219.nnue     :   -12.7    5.3    2775.0    5760   48
3 run_0/nn-epoch239.nnue     :   -13.3    7.5    1385.0    2880   48
4 run_0/nn-epoch179.nnue     :   -17.0    3.7    5479.0   11520   48
5 run_0/nn-epoch159.nnue     :   -18.1    3.7    5460.0   11520   47
```