### PR TITLE
Increase L1 size to 1536 for new SFNNv6 net

### DIFF
--- a/model.py
+++ b/model.py
@@ -7,7 +7,7 @@ import copy
 from feature_transformer import DoubleFeatureTransformerSlice
 
 # 3 layer fully connected network
-L1 = 1024
+L1 = 1536
 L2 = 15
 L3 = 32
 


### PR DESCRIPTION
This was used to train a larger master net nn-8d69132723e2.nnue in:
https://github.com/official-stockfish/Stockfish/pull/4593