### PR TITLE
Update default network testing book to match new fishtest book

### DIFF
--- a/scripts/easy_train.py
+++ b/scripts/easy_train.py
@@ -2114,7 +2114,7 @@ def parse_cli_args():
     )
     parser.add_argument(
         '--network-testing-book',
-        default='https://github.com/official-stockfish/books/raw/master/UHO_XXL_+0.90_+1.19.epd.zip',
+        default='https://github.com/official-stockfish/books/raw/master/UHO_4060_v2.epd.zip',
         type=str,
         metavar='PATH_OR_URL',
         dest='network_testing_book',

--- a/scripts/easy_train_example.bat
+++ b/scripts/easy_train_example.bat
@@ -21,7 +21,7 @@ python easy_train.py ^
     --validation-size=4096 ^
     --network-testing-threads=2 ^
     --network-testing-explore-factor=1.5 ^
-    --network-testing-book="https://github.com/official-stockfish/books/raw/master/UHO_XXL_%%2B0.90_%%2B1.19.epd.zip" ^
+    --network-testing-book="https://github.com/official-stockfish/books/raw/master/UHO_4060_v2.epd.zip" ^
     --network-testing-nodes-per-move=1000 ^
     --network-testing-hash-mb=8 ^
     --network-testing-games-per-round=200 ^

--- a/scripts/easy_train_example.sh
+++ b/scripts/easy_train_example.sh
@@ -21,7 +21,7 @@ python easy_train.py \
     --validation-size=16384 \
     --network-testing-threads=24 \
     --network-testing-explore-factor=1.5 \
-    --network-testing-book="https://github.com/official-stockfish/books/raw/master/UHO_XXL_+0.90_+1.19.epd.zip" \
+    --network-testing-book="https://github.com/official-stockfish/books/raw/master/UHO_4060_v2.epd.zip" \
     --network-testing-nodes-per-move=20000 \
     --network-testing-hash-mb=8 \
     --network-testing-games-per-round=200 \


### PR DESCRIPTION
Since the fishtest book was changed from `UHO_XXL_+0.90_+1.19.epd` to `UHO_4060_v2.epd` during SF16 release.