### PR TITLE
Add support for multiple datasets in the trainer. The datasets are in…

### DIFF
--- a/nnue_dataset.py
+++ b/nnue_dataset.py
@@ -67,12 +67,17 @@ class FenBatch(ctypes.Structure):
         return strings
 
 FenBatchPtr = ctypes.POINTER(FenBatch)
-# EXPORT FenBatchStream* CDECL create_fen_batch_stream(int concurrency, const char* filename, int batch_size, bool cyclic, bool filtered, int random_fen_skipping, bool wld_filtered, int param_index)
+# EXPORT FenBatchStream* CDECL create_fen_batch_stream(int concurrency, int num_files, const char* const* filenames, int batch_size, bool cyclic, bool filtered, int random_fen_skipping, bool wld_filtered, int early_fen_skipping, int param_index)
 create_fen_batch_stream = dll.create_fen_batch_stream
 create_fen_batch_stream.restype = ctypes.c_void_p
-create_fen_batch_stream.argtypes = [ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_bool, ctypes.c_bool, ctypes.c_int, ctypes.c_bool, ctypes.c_int, ctypes.c_int]
+create_fen_batch_stream.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.POINTER(ctypes.c_char_p), ctypes.c_int, ctypes.c_bool, ctypes.c_bool, ctypes.c_int, ctypes.c_bool, ctypes.c_int, ctypes.c_int]
 destroy_fen_batch_stream = dll.destroy_fen_batch_stream
 destroy_fen_batch_stream.argtypes = [ctypes.c_void_p]
+
+def make_fen_batch_stream(concurrency, filenames, batch_size, cyclic, filtered, random_fen_skipping, wld_filtered, early_fen_skipping, param_index):
+    filenames_ = (ctypes.c_char_p * len(filenames))()
+    filenames_[:] = [filename.encode('utf-8') for filename in filenames]
+    return create_fen_batch_stream(concurrency, len(filenames), filenames_, batch_size, cyclic, filtered, random_fen_skipping, wld_filtered, early_fen_skipping, param_index)
 
 fetch_next_fen_batch = dll.fetch_next_fen_batch
 fetch_next_fen_batch.restype = FenBatchPtr
@@ -103,9 +108,9 @@ class FenBatchProvider:
         self.param_index = param_index
 
         if batch_size:
-            self.stream = create_fen_batch_stream(self.num_workers, self.filename, batch_size, cyclic, filtered, random_fen_skipping, wld_filtered, early_fen_skipping, param_index)
+            self.stream = make_fen_batch_stream(self.num_workers, [self.filename], batch_size, cyclic, filtered, random_fen_skipping, wld_filtered, early_fen_skipping, param_index)
         else:
-            self.stream = create_fen_batch_stream(self.num_workers, self.filename, cyclic, filtered, random_fen_skipping, wld_filtered, early_fen_skipping, param_index)
+            self.stream = make_fen_batch_stream(self.num_workers, [self.filename], cyclic, filtered, random_fen_skipping, wld_filtered, early_fen_skipping, param_index)
 
     def __iter__(self):
         return self
@@ -131,7 +136,7 @@ class TrainingDataProvider:
         destroy_stream,
         fetch_next,
         destroy_part,
-        filename,
+        filenames,
         cyclic,
         num_workers,
         batch_size=None,
@@ -147,7 +152,7 @@ class TrainingDataProvider:
         self.destroy_stream = destroy_stream
         self.fetch_next = fetch_next
         self.destroy_part = destroy_part
-        self.filename = filename.encode('utf-8')
+        self.filenames = filenames
         self.cyclic = cyclic
         self.num_workers = num_workers
         self.batch_size = batch_size
@@ -158,9 +163,9 @@ class TrainingDataProvider:
         self.device = device
 
         if batch_size:
-            self.stream = self.create_stream(self.feature_set, self.num_workers, self.filename, batch_size, cyclic, filtered, random_fen_skipping, wld_filtered, early_fen_skipping, param_index)
+            self.stream = self.create_stream(self.feature_set, self.num_workers, self.filenames, batch_size, cyclic, filtered, random_fen_skipping, wld_filtered, early_fen_skipping, param_index)
         else:
-            self.stream = self.create_stream(self.feature_set, self.num_workers, self.filename, cyclic, filtered, random_fen_skipping, wld_filtered, early_fen_skipping, param_index)
+            self.stream = self.create_stream(self.feature_set, self.num_workers, self.filenames, cyclic, filtered, random_fen_skipping, wld_filtered, early_fen_skipping, param_index)
 
     def __iter__(self):
         return self
@@ -178,13 +183,18 @@ class TrainingDataProvider:
     def __del__(self):
         self.destroy_stream(self.stream)
 
-#    EXPORT Stream<SparseBatch>* CDECL create_sparse_batch_stream(const char* feature_set_c, int concurrency, const char* filename, int batch_size, bool cyclic,
+#    EXPORT Stream<SparseBatch>* CDECL create_sparse_batch_stream(const char* feature_set_c, int concurrency, int num_files, const char* const* filenames, int batch_size, bool cyclic,
 #                                                                 bool filtered, int random_fen_skipping, bool wld_filtered, int early_fen_skipping, int param_index)
 create_sparse_batch_stream = dll.create_sparse_batch_stream
 create_sparse_batch_stream.restype = ctypes.c_void_p
-create_sparse_batch_stream.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_char_p, ctypes.c_int, ctypes.c_bool, ctypes.c_bool, ctypes.c_int, ctypes.c_bool, ctypes.c_int, ctypes.c_int]
+create_sparse_batch_stream.argtypes = [ctypes.c_char_p, ctypes.c_int, ctypes.c_int, ctypes.POINTER(ctypes.c_char_p), ctypes.c_int, ctypes.c_bool, ctypes.c_bool, ctypes.c_int, ctypes.c_bool, ctypes.c_int, ctypes.c_int]
 destroy_sparse_batch_stream = dll.destroy_sparse_batch_stream
 destroy_sparse_batch_stream.argtypes = [ctypes.c_void_p]
+
+def make_sparse_batch_stream(feature_set, concurrency, filenames, batch_size, cyclic, filtered, random_fen_skipping, wld_filtered, early_fen_skipping, param_index):
+    filenames_ = (ctypes.c_char_p * len(filenames))()
+    filenames_[:] = [filename.encode('utf-8') for filename in filenames]
+    return create_sparse_batch_stream(feature_set, concurrency, len(filenames), filenames_, batch_size, cyclic, filtered, random_fen_skipping, wld_filtered, early_fen_skipping, param_index)
 
 fetch_next_sparse_batch = dll.fetch_next_sparse_batch
 fetch_next_sparse_batch.restype = SparseBatchPtr
@@ -211,14 +221,14 @@ def make_sparse_batch_from_fens(feature_set, fens, scores, plies, results):
     return b
 
 class SparseBatchProvider(TrainingDataProvider):
-    def __init__(self, feature_set, filename, batch_size, cyclic=True, num_workers=1, filtered=False, random_fen_skipping=0, wld_filtered=False, early_fen_skipping=-1, param_index=0, device='cpu'):
+    def __init__(self, feature_set, filenames, batch_size, cyclic=True, num_workers=1, filtered=False, random_fen_skipping=0, wld_filtered=False, early_fen_skipping=-1, param_index=0, device='cpu'):
         super(SparseBatchProvider, self).__init__(
             feature_set,
-            create_sparse_batch_stream,
+            make_sparse_batch_stream,
             destroy_sparse_batch_stream,
             fetch_next_sparse_batch,
             destroy_sparse_batch,
-            filename,
+            filenames,
             cyclic,
             num_workers,
             batch_size,
@@ -230,10 +240,10 @@ class SparseBatchProvider(TrainingDataProvider):
             device)
 
 class SparseBatchDataset(torch.utils.data.IterableDataset):
-  def __init__(self, feature_set, filename, batch_size, cyclic=True, num_workers=1, filtered=False, random_fen_skipping=0, wld_filtered=False, early_fen_skipping=-1, param_index=0, device='cpu'):
+  def __init__(self, feature_set, filenames, batch_size, cyclic=True, num_workers=1, filtered=False, random_fen_skipping=0, wld_filtered=False, early_fen_skipping=-1, param_index=0, device='cpu'):
     super(SparseBatchDataset).__init__()
     self.feature_set = feature_set
-    self.filename = filename
+    self.filenames = filenames
     self.batch_size = batch_size
     self.cyclic = cyclic
     self.num_workers = num_workers
@@ -245,7 +255,7 @@ class SparseBatchDataset(torch.utils.data.IterableDataset):
     self.device = device
 
   def __iter__(self):
-    return SparseBatchProvider(self.feature_set, self.filename, self.batch_size, cyclic=self.cyclic, num_workers=self.num_workers,
+    return SparseBatchProvider(self.feature_set, self.filenames, self.batch_size, cyclic=self.cyclic, num_workers=self.num_workers,
                                filtered=self.filtered, random_fen_skipping=self.random_fen_skipping, wld_filtered=self.wld_filtered, early_fen_skipping = self.early_fen_skipping, param_index=self.param_index, device=self.device)
 
 class FixedNumBatchesDataset(Dataset):

--- a/scripts/easy_train_example.bat
+++ b/scripts/easy_train_example.bat
@@ -1,6 +1,7 @@
 python easy_train.py ^
     --training-dataset=c:/dev/nnue-pytorch/noob_master_leaf_static_d12_85M_0.binpack ^
-    --validation-dataset=c:/dev/nnue-pytorch/d8_100000.binpack ^
+    --training-dataset=c:/dev/nnue-pytorch/d8_100000.binpack ^
+    --training-dataset=c:/dev/nnue-pytorch/10m_d3_2.binpack ^
     --num-workers=1 ^
     --threads=1 ^
     --gpus="0," ^


### PR DESCRIPTION
…terleaved at binpack chunk granularity.

Handling cyclic binpack reading was moved from `BinpackSfenInputParallelStream` to `CompressedTrainingDataEntryParallelReader` to allow for cycling each dataset individually.

train.py accepts any number of positional arguments - paths to the datasets to use. Validation will use the same datasets unless overriden by `--validation-data`, which can be present multiple times (or have multiple values) to specify multiple datasets.

easy_train.py now can have multiple instances of `--training-dataset` and `--validation-dataset` (or accept multiple values for each).

C API changed, additional helper functions were made to wrap conversion of string list to array of char* for `create_fen_batch_stream` and `create_sparse_batch_stream`.

Also kinda deprecate .bin, currently won't work with multiple datasets. No one was using it anyway, we should remove it (at least don't allow it in the trainer) next time.

---------------------------------------------------------------------

I tested easy_train.py briefly, but I would like someone to do a full training run and compare the results with a manually interleaved dataset. The semantics should be similar, but there are some changes to the data loader that could manifest issues when re-reading datasets (requires a long training session), and also to make sure the interleaving is similar enough.

@linrock 