### PR TITLE
Backport changes needed for master nets

### DIFF
--- a/data_loader/config.py
+++ b/data_loader/config.py
@@ -10,6 +10,9 @@ class DataloaderSkipConfig:
     early_fen_skipping: int = -1
     simple_eval_skipping: int = -1
     param_index: int = 0
+    pc_y1: float = 1.0
+    pc_y2: float = 2.0
+    pc_y3: float = 1.0
 
 
 class CDataloaderSkipConfig(ctypes.Structure):
@@ -20,6 +23,9 @@ class CDataloaderSkipConfig(ctypes.Structure):
         ("early_fen_skipping", ctypes.c_int),
         ("simple_eval_skipping", ctypes.c_int),
         ("param_index", ctypes.c_int),
+        ("pc_y1", ctypes.c_double),
+        ("pc_y2", ctypes.c_double),
+        ("pc_y3", ctypes.c_double),
     ]
 
     def __init__(self, config: DataloaderSkipConfig):
@@ -30,4 +36,7 @@ class CDataloaderSkipConfig(ctypes.Structure):
             early_fen_skipping=config.early_fen_skipping,
             simple_eval_skipping=config.simple_eval_skipping,
             param_index=config.param_index,
+            pc_y1=config.pc_y1,
+            pc_y2=config.pc_y2,
+            pc_y3=config.pc_y3,
         )

--- a/model/config.py
+++ b/model/config.py
@@ -20,3 +20,5 @@ class LossParams:
     end_lambda: float = 1.0
     pow_exp: float = 2.5
     qp_asymmetry: float = 0.0
+    w1: float = 0.0
+    w2: float = 0.5

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -106,7 +106,9 @@ class NNUE(L.LightningModule):
         loss = torch.pow(torch.abs(pt - qf), p.pow_exp)
         if p.qp_asymmetry != 0.0:
             loss = loss * ((qf > pt) * p.qp_asymmetry + 1)
-        loss = loss.mean()
+
+        weights = 1 + (2.0**p.w1 - 1) * torch.pow((pf - 0.5) ** 2 * pf * (1 - pf), p.w2)
+        loss = (loss * weights).sum() / weights.sum()
 
         self.log(loss_type, loss, prog_bar=True)
 

--- a/train.py
+++ b/train.py
@@ -333,6 +333,42 @@ def main():
         dest="simple_eval_skipping",
         help="Skip positions that have abs(simple_eval(pos)) < n",
     )
+    parser.add_argument(
+        "--pc-y1",
+        type=float,
+        default=1.0,
+        dest="pc_y1",
+        help="piece count parameter y1 (default=1.0)",
+    )
+    parser.add_argument(
+        "--pc-y2",
+        type=float,
+        default=2.0,
+        dest="pc_y2",
+        help="piece count parameter y2 (default=2.0)",
+    )
+    parser.add_argument(
+        "--pc-y3",
+        type=float,
+        default=1.0,
+        dest="pc_y3",
+        help="piece count parameter y3 (default=1.0)",
+    )
+    parser.add_argument(
+        "--w1",
+        type=float,
+        default=0.0,
+        dest="w1",
+        help="weight boost parameter 1 (default=0.0)",
+    )
+    parser.add_argument(
+        "--w2",
+        type=float,
+        default=0.5,
+        dest="w2",
+        help="weight boost parameter 2 (default=0.5)",
+    )
+
     parser.add_argument("--l1", type=int, default=M.ModelConfig().L1)
     M.add_feature_args(parser)
     args = parser.parse_args()
@@ -377,6 +413,8 @@ def main():
         end_lambda=args.end_lambda or args.lambda_,
         pow_exp=args.pow_exp,
         qp_asymmetry=args.qp_asymmetry,
+        w1=args.w1,
+        w2=args.w2,
     )
     print("Loss parameters:")
     print(loss_params)
@@ -429,6 +467,11 @@ def main():
     print("Skip early plies: {}".format(args.early_fen_skipping))
     print("Skip simple eval : {}".format(args.simple_eval_skipping))
     print("Param index: {}".format(args.param_index))
+    print("piececount param y1 : {}".format(args.pc_y1))
+    print("piececount param y2 : {}".format(args.pc_y2))
+    print("piececount param y3 : {}".format(args.pc_y3))
+    print("Weighting param w1 : {}".format(args.w1))
+    print("Weighting param w2 : {}".format(args.w2))
 
     if args.threads > 0:
         print("limiting torch to {} threads.".format(args.threads))
@@ -481,6 +524,9 @@ def main():
             early_fen_skipping=args.early_fen_skipping,
             simple_eval_skipping=args.simple_eval_skipping,
             param_index=args.param_index,
+            pc_y1=args.pc_y1,
+            pc_y2=args.pc_y2,
+            pc_y3=args.pc_y3,
         ),
         args.epoch_size,
         args.validation_size,


### PR DESCRIPTION
this introduces two changes needed for training SF master nets, in particular for executing the recipes referenced in

https://github.com/official-stockfish/Stockfish/pull/6452

https://github.com/official-stockfish/Stockfish/pull/6457

adding some additional flexibility for shaping the piece count distribution and weighting the individual configurations in the loss respectively.