### PR TITLE
Fix legacy Shogi terminology

### DIFF
--- a/lib/nnue_training_data_formats.h
+++ b/lib/nnue_training_data_formats.h
@@ -6572,8 +6572,7 @@ namespace binpack
                 // Side to move.
                 stream.write_one_bit((int)(pos.sideToMove()));
 
-                // 7-bit positions for leading and trailing pieces
-                // White king and black king, 6 bits for each.
+                // 6-bit positions for White and Black Kings
                 stream.write_n_bit(static_cast<int>(pos.kingSquare(chess::Color::White)), 6);
                 stream.write_n_bit(static_cast<int>(pos.kingSquare(chess::Color::Black)), 6);
 


### PR DESCRIPTION
Fix legacy Shogi terminology.

This PR updates a few comments that appear to be legacy artifacts from a Shogi port.

Specifically, the comments refer to "balls" (a literal translation of "Gyoku", referring to the King in Shogi). These have been corrected to "Kings" to accurately reflect the Chess context and the specific logic of the code, which places the Kings onto the board explicitly before placing the remaining pieces.

Also, this fixes the bit-width (Chess uses 6 bits for 64 squares, not 7 for 81) and replaces Shogi terms ("leading/trailing", "balls") with Chess equivalents ("White/Black", "Kings").