### PR TITLE
chore: pin pytorch version to 2.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ numba
 numpy<2.0
 requests
 lightning
+torch==2.10.0


### PR DESCRIPTION
The torch version shouldn't be loose. 

Tested with the latest stable torch (2.10.0) and training works fine.