### PR TITLE
run_docker.sh fix

### DIFF
--- a/run_docker.sh
+++ b/run_docker.sh
@@ -33,10 +33,19 @@ read DATA_PATH
 DATA_PATH=${DATA_PATH}
 echo "Using data path: $DATA_PATH"
 
+# Checking if docker is in rootless mode.
+if docker info 2>/dev/null | grep -iq "rootless"; then
+    echo "Rootless mode detected."
+    USER_FLAG="--user 0:0"
+else
+    echo "Standard mode detected."
+    USER_FLAG="--user $(id -u):$(id -g)"
+fi
+
 echo "Creating new container 'nnue-container'..."
 docker run -it \
   $GPU_FLAGS \
-  -u `id -u` \
+  $USER_FLAG \
   -v "$(pwd)":/workspace/nnue-pytorch \
   -v "$DATA_PATH":/data \
   --ipc=host \


### PR DESCRIPTION
It is a good addition to let people run docker without root rights (e.g. on some cluster).

Right now when trying to run in rootless mode, python will throw an Exception due to an unknown uid. When run in rootless mode, the only valid uid becomes 0.

With this fix run_docker.sh automatically detects if docker is configured in rootless mode and will pass the correct user flag to the docker run command.
