### PR TITLE
Fix: Remove some unnecessary tensor copy operations from model

### DIFF
--- a/model/model.py
+++ b/model/model.py
@@ -1,4 +1,5 @@
 import torch
+import torch.nn.functional as F
 from torch import nn
 
 from .config import ModelConfig
@@ -46,7 +47,6 @@ class NNUEModel(nn.Module):
         We zero all virtual feature weights because there's not need for them
         to be initialized; they only aid the training of correlated features.
         """
-        weights = self.input.weight
         with torch.no_grad():
             for a, b in self.feature_set.get_virtual_feature_ranges():
                 self.input.weight[a:b, :].zero_()

--- a/model/modules/feature_transformer/module.py
+++ b/model/modules/feature_transformer/module.py
@@ -29,7 +29,7 @@ class BaseFeatureTransformer(nn.Module):
             return
 
         with torch.no_grad():
-            new_weight = F.pad(self.weight.data, (0, 0, 0, additional_features), value=0)
+            new_weight = F.pad(self.weight, (0, 0, 0, additional_features), value=0)
             
             self.weight = nn.Parameter(new_weight)
             self.num_inputs += additional_features


### PR DESCRIPTION
Right now there are some unnecessary tensor copies particularly for weight clipping. Omitting those copies doesn't seem t speed up the training, but it is arguably cleaner