### PR TITLE
Add build-pgo-generate to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 env/
 build/
+build-pgo-generate/
 logs/
 testing
 libtraining_data_loader.*


### PR DESCRIPTION
the new dataloader compiles in build-pgo-generate and removes the directory at the end. Better ignore the directory in case the script gets halted for whatever reason