### PR TITLE
Fix incorrect scaling

### DIFF
--- a/model/model.py
+++ b/model/model.py
@@ -86,16 +86,18 @@ class NNUEModel(nn.Module):
 
         l0_s = torch.split(l0_, self.L1 // 2, dim=1)
         l0_s1 = [l0_s[0] * l0_s[1], l0_s[2] * l0_s[3]]
-        # We multiply by 127/128 because in the quantized network 1.0 is represented by 127
-        # and it's more efficient to divide by 128 instead.
-        l0_ = torch.cat(l0_s1, dim=1) * (127 / 128)
+        l0_ = torch.cat(l0_s1, dim=1)
 
         psqt_indices_unsq = psqt_indices.unsqueeze(dim=1)
         wpsqt = wpsqt.gather(1, psqt_indices_unsq)
         bpsqt = bpsqt.gather(1, psqt_indices_unsq)
+
         # The PSQT values are averaged over perspectives. "Their" perspective
         # has a negative influence (us-0.5 is 0.5 for white and -0.5 for black,
         # which does both the averaging and sign flip for black to move)
-        x = self.layer_stacks(l0_, layer_stack_indices) + (wpsqt - bpsqt) * (us - 0.5)
+        nnue = self.layer_stacks(l0_, layer_stack_indices)
+        psqt = (wpsqt - bpsqt) * (us - 0.5)
+
+        x = nnue + psqt
 
         return x

--- a/model/modules/layer_stacks.py
+++ b/model/modules/layer_stacks.py
@@ -30,9 +30,9 @@ class LayerStacks(nn.Module):
     def forward(self, x: torch.Tensor, ls_indices: torch.Tensor):
         l1c_ = self.l1(x, ls_indices)
         l1x_, l1x_out = l1c_.split(self.L2, dim=1)
-        # multiply sqr crelu result by (255/256) to match quantized version
+        # multiply sqr crelu result by (127/128) to match quantized version
         l1x_ = torch.clamp(
-            torch.cat([torch.pow(l1x_, 2.0) * (255 / 256), l1x_], dim=1), 0.0, 1.0
+            torch.cat([torch.pow(l1x_, 2.0) * (127 / 128), l1x_], dim=1), 0.0, 1.0
         )
 
         l2c_ = self.l2(l1x_, ls_indices)


### PR DESCRIPTION
This scaling factor is necessary prior to #373, but has been broken since the quantization change that came with it.

### Before #373

Our quantization scale is 127. This means at `l0_s`, 1_trainer = 127_sf.

In the quantized SF inference, the intermediary scale after screlu is 127^2. We correct it by dividing 128:

127 => 127^2 => 127^2/128 => 126.0078125

The same value goes though the pytorch inference:

1 => 1^2 => 1^2*127/128 => 0.9921875

And because 127*0.9921875 = 126.0078125, the numbers after pairwise is consistent with the 127 quantization scale

### After #373 

Our quantization scale is 255 before pairwise screlu, and 127 after pairwise screlu. At `l0_s`, 1_trainer = 255_sf

In the quantized SF inference, the intermediary scale is 255^2. We correct it by dividing 512:

255 => 255^2 => 255^2/512 => 127.001953125

For the current pytorch:

1 => 1^2 => 1^2*127/128 => 0.9921875

This is a problem: the SF inference no longer biases the outputs by a scale of 127/128 (but rather a negligible amount), while the trainer still accounts for the bias. The fix is to remove the scaling altogether, as the 0.01% error is too small to change the results of the quantized arithmetic.