### PR TITLE
Optionally use tsan for the data loader

### DIFF
--- a/compile_data_loader.sh
+++ b/compile_data_loader.sh
@@ -35,10 +35,10 @@ cmake -S "$SRC_DIR" -B "$BUILD_DIR" \
   -DLIB_COPY_DIR="$ROOT_DIR"
 
 echo "Building instrumented targets..."
-cmake --build "$BUILD_DIR"
+cmake --build "$BUILD_DIR" -j
 
 echo "Running bench to generate profile data (pgo_run)..."
-cmake --build "$BUILD_DIR" --target pgo_run
+cmake --build "$BUILD_DIR" --target pgo_run -j
 
 echo "Re-configuring for PGO_Use (use collected profiles)..."
 cmake -S "$SRC_DIR" -B "$BUILD_DIR" \
@@ -48,7 +48,7 @@ cmake -S "$SRC_DIR" -B "$BUILD_DIR" \
   -DLIB_COPY_DIR="$ROOT_DIR"
 
 echo "Building shared library with profile data (training_data_loader)..."
-cmake --build "$BUILD_DIR"
+cmake --build "$BUILD_DIR" -j
 
 echo "PGO build complete."
 

--- a/data_loader/cpp/CMakeLists.txt
+++ b/data_loader/cpp/CMakeLists.txt
@@ -11,7 +11,7 @@ string(TOUPPER "${CMAKE_BUILD_TYPE}" UPPER_BUILD_TYPE)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-set(CMAKE_CXX_FLAGS_DEBUG "-g")
+set(CMAKE_CXX_FLAGS_DEBUG "-g -march=native")
 set(CMAKE_CXX_FLAGS_RELEASE "-O3 -march=native -DNDEBUG")
 set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-g -O3 -march=native -DNDEBUG")
 
@@ -26,6 +26,13 @@ if(UPPER_BUILD_TYPE STREQUAL "PGO_GENERATE" AND NOT PGO_INPUT)
   message(FATAL_ERROR
     "PGO_Generate build requires a non-empty PGO_INPUT.\n"
     "Re-run CMake with -DPGO_INPUT=<path-to-input-file>.")
+endif()
+
+option(ENABLE_TSAN "Enable ThreadSanitizer" OFF)
+
+if(ENABLE_TSAN)
+  add_compile_options(-fsanitize=thread -fno-omit-frame-pointer)
+  add_link_options(-fsanitize=thread)
 endif()
 
 set(CMAKE_CXX_FLAGS_PGO_GENERATE "${CMAKE_CXX_FLAGS_RELEASE}")
@@ -51,20 +58,21 @@ execute_process(
 )
 
 if(VENDOR_ID STREQUAL "AuthenticAMD")
-    if(CPU_FAMILY GREATER_EQUAL "23" AND CPU_BMI2 STREQUAL "bmi2")
-        set(CPU_SUPPORTS_BMI2 TRUE)
-    endif()
-elseif(CPU_BMI2 STREQUAL "bmi2")
+  if(CPU_FAMILY GREATER_EQUAL "23" AND CPU_BMI2 STREQUAL "bmi2")
     set(CPU_SUPPORTS_BMI2 TRUE)
+  endif()
+elseif(CPU_BMI2 STREQUAL "bmi2")
+  set(CPU_SUPPORTS_BMI2 TRUE)
 else()
-    set(CPU_SUPPORTS_BMI2 FALSE)
+  set(CPU_SUPPORTS_BMI2 FALSE)
 endif()
 
 if(CPU_SUPPORTS_BMI2)
-    message(STATUS "Adding BMI2 support")
-    add_definitions(-DHAS_BMI2)
+  message(STATUS "Adding BMI2 support")
+  add_definitions(-DHAS_BMI2)
+  add_compile_options(-mbmi2)
 else()
-    message(STATUS "No BMI2 support")
+  message(STATUS "No BMI2 support")
 endif()
 
 find_package(Threads REQUIRED)
@@ -82,9 +90,11 @@ set_target_properties(training_data_loader PROPERTIES
 )
 
 # Platform-independent copy of the shared library
-add_custom_command(TARGET training_data_loader POST_BUILD
-  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:training_data_loader> "${LIB_COPY_DIR}/"
-)
+if(LIB_COPY_DIR)
+  add_custom_command(TARGET training_data_loader POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:training_data_loader> "${LIB_COPY_DIR}/"
+  )
+endif()
 
 # pgo generation target
 if(UPPER_BUILD_TYPE STREQUAL "PGO_GENERATE")


### PR DESCRIPTION
can be used to test the data loader as:

rm -fR build
cmake -S data_loader/cpp -B build -DCMAKE_BUILD_TYPE=RelWithDebInfo  -DENABLE_TSAN=ON cmake --build build -j --verbose
build/training_data_loader_bench -i 5 -p 4 -c 0 .pgo/small.binpack

Also use -j by default in the build script
Always pass -march=native to ensure compilation if bmi2 is detected.