### PR TITLE
Fix Logging for Validation

### DIFF
--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -214,8 +214,8 @@ class NNUE(L.LightningModule):
             loss,
             prog_bar=False,
             sync_dist=True,
-            on_epoch=False,
-            on_step=True,
+            on_epoch=True,
+            on_step=False,
         )
 
         return loss

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -133,19 +133,19 @@ class NNUE(L.LightningModule):
 
     def on_train_epoch_end(self):
         self.optimizer_wrapper.on_train_epoch_end(self)
-        self._log_epoch_end("train_loss")
+        self._log_epoch_end("train_loss_epoch")
 
     def on_validation_epoch_start(self):
         self.optimizer_wrapper.on_validation_epoch_start(self)
 
     def on_validation_epoch_end(self):
-        self._log_epoch_end("val_loss")
+        self._log_epoch_end("val_loss_epoch")
 
     def on_test_epoch_start(self):
         self.optimizer_wrapper.on_test_epoch_start(self)
 
     def on_test_epoch_end(self):
-        self._log_epoch_end("test_loss")
+        self._log_epoch_end("test_loss_epoch")
 
     def on_save_checkpoint(self, checkpoint):
         self.optimizer_wrapper.on_save_checkpoint(self, checkpoint)
@@ -155,8 +155,8 @@ class NNUE(L.LightningModule):
 
     def _log_epoch_end(self, loss_type):
         self.log(
-            f"{loss_type}_epoch",
-            self.loss_metrics[f"{loss_type}_epoch"],
+            f"{loss_type}",
+            self.loss_metrics[f"{loss_type}"],
             prog_bar=False,
             sync_dist=True,
             on_epoch=True,
@@ -235,7 +235,7 @@ class NNUE(L.LightningModule):
         weights = 1 + (2.0**p.w1 - 1) * torch.pow((pf - 0.5) ** 2 * pf * (1 - pf), p.w2)
         loss = (loss * weights).sum() / weights.sum()
 
-        self.loss_metrics[f"{loss_type}_epoch"](loss)
+        self.loss_metrics[f"{loss_type}_epoch"].update(loss)
         self.log(
             loss_type,
             loss,

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -1,6 +1,7 @@
 import lightning as L
 import torch
 from torch import Tensor, nn
+from torchmetrics import MeanMetric, MetricCollection
 
 from .config import NNUELightningConfig
 from .model import NNUEModel
@@ -49,6 +50,12 @@ class NNUE(L.LightningModule):
 
         # lazy init so `resume_from_model` with config changes works correctly
         self.optimizer_wrapper = None
+
+        self.loss_metrics = MetricCollection ({
+            "train_loss_epoch": MeanMetric(),
+            "val_loss_epoch": MeanMetric(),
+            "test_loss_epoch": MeanMetric(),
+        })
 
     # --- setup optimizers and training hooks ---
     def configure_optimizers(self):
@@ -155,6 +162,8 @@ class NNUE(L.LightningModule):
 
     @torch.compiler.disable
     def _log(self, loss_type, loss):
+        self.loss_metrics[f"{loss_type}_epoch"](loss)
+
         self.log(
             loss_type,
             loss,
@@ -166,7 +175,7 @@ class NNUE(L.LightningModule):
 
         self.log(
             f"{loss_type}_epoch",
-            loss,
+            self.loss_metrics[f"{loss_type}_epoch"],
             prog_bar=False,
             sync_dist=True,
             on_epoch=True,

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -133,18 +133,35 @@ class NNUE(L.LightningModule):
 
     def on_train_epoch_end(self):
         self.optimizer_wrapper.on_train_epoch_end(self)
+        self._log_epoch_end("train_loss")
 
     def on_validation_epoch_start(self):
         self.optimizer_wrapper.on_validation_epoch_start(self)
 
+    def on_validation_epoch_end(self):
+        self._log_epoch_end("val_loss")
+
     def on_test_epoch_start(self):
         self.optimizer_wrapper.on_test_epoch_start(self)
+
+    def on_test_epoch_end(self):
+        self._log_epoch_end("test_loss")
 
     def on_save_checkpoint(self, checkpoint):
         self.optimizer_wrapper.on_save_checkpoint(self, checkpoint)
 
     def on_train_batch_start(self, batch, batch_idx):
         self.optimizer_wrapper.on_train_batch_start(self, batch, batch_idx)
+
+    def _log_epoch_end(self, loss_type):
+        self.log(
+            f"{loss_type}_epoch",
+            self.loss_metrics[f"{loss_type}_epoch"],
+            prog_bar=False,
+            sync_dist=True,
+            on_epoch=True,
+            on_step=False,
+        )
 
     # --- Training step implementation ---
 
@@ -161,27 +178,6 @@ class NNUE(L.LightningModule):
     @torch.no_grad()
     def test_step(self, batch, batch_idx):
         self.step_(batch, batch_idx, "test_loss")
-
-    def _log(self, loss_type, loss):
-        self.loss_metrics[f"{loss_type}_epoch"](loss)
-
-        self.log(
-            loss_type,
-            loss,
-            prog_bar=False,
-            sync_dist=False,
-            on_epoch=False,
-            on_step=True,
-        )
-
-        self.log(
-            f"{loss_type}_epoch",
-            self.loss_metrics[f"{loss_type}_epoch"],
-            prog_bar=False,
-            sync_dist=True,
-            on_epoch=True,
-            on_step=False,
-        )
 
     def step_(self, batch: tuple[Tensor, ...], batch_idx, loss_type):
         _ = batch_idx  # unused, but required by pytorch-lightning
@@ -239,6 +235,13 @@ class NNUE(L.LightningModule):
         weights = 1 + (2.0**p.w1 - 1) * torch.pow((pf - 0.5) ** 2 * pf * (1 - pf), p.w2)
         loss = (loss * weights).sum() / weights.sum()
 
-        self._log(loss_type, loss)
-
+        self.loss_metrics[f"{loss_type}_epoch"](loss)
+        self.log(
+            loss_type,
+            loss,
+            prog_bar=False,
+            sync_dist=False,
+            on_epoch=False,
+            on_step=True,
+        )
         return loss

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -154,9 +154,11 @@ class NNUE(L.LightningModule):
     def training_step(self, batch, batch_idx):
         return self.step_(batch, batch_idx, "train_loss")
 
+    @torch.no_grad()
     def validation_step(self, batch, batch_idx):
         self.step_(batch, batch_idx, "val_loss")
 
+    @torch.no_grad()
     def test_step(self, batch, batch_idx):
         self.step_(batch, batch_idx, "test_loss")
 

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -153,6 +153,26 @@ class NNUE(L.LightningModule):
     def test_step(self, batch, batch_idx):
         self.step_(batch, batch_idx, "test_loss")
 
+    @torch.compiler.disable
+    def _log(self, loss_type, loss):
+        self.log(
+            loss_type,
+            loss,
+            prog_bar=False,
+            sync_dist=False,
+            on_epoch=False,
+            on_step=True,
+        )
+
+        self.log(
+            f"{loss_type}_epoch",
+            loss,
+            prog_bar=False,
+            sync_dist=True,
+            on_epoch=True,
+            on_step=False,
+        )
+
     def step_(self, batch: tuple[Tensor, ...], batch_idx, loss_type):
         _ = batch_idx  # unused, but required by pytorch-lightning
 
@@ -209,13 +229,6 @@ class NNUE(L.LightningModule):
         weights = 1 + (2.0**p.w1 - 1) * torch.pow((pf - 0.5) ** 2 * pf * (1 - pf), p.w2)
         loss = (loss * weights).sum() / weights.sum()
 
-        self.log(
-            loss_type,
-            loss,
-            prog_bar=False,
-            sync_dist=True,
-            on_epoch=True,
-            on_step=False,
-        )
+        self._log(loss_type, loss)
 
         return loss

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -162,7 +162,6 @@ class NNUE(L.LightningModule):
     def test_step(self, batch, batch_idx):
         self.step_(batch, batch_idx, "test_loss")
 
-    @torch.compiler.disable
     def _log(self, loss_type, loss):
         self.loss_metrics[f"{loss_type}_epoch"](loss)
 

--- a/model/model.py
+++ b/model/model.py
@@ -36,6 +36,7 @@ class NNUEModel(nn.Module):
 
         self.input.init_weights(num_psqt_buckets, self.quantization.nnue2score)
 
+    @torch.no_grad()
     def clip_weights(self):
         """
         Clips the weights of the model based on the min/max values allowed

--- a/train.py
+++ b/train.py
@@ -115,6 +115,7 @@ class SimpleLineLogger(Callback):
                 f"[{self._format_time(elapsed_total)}<{self._format_time(remaining)}, "
                 f"{rate:>6.2f}it/s, "
                 f"{self.train_metric_step}={loss_val:.5f}]",
+                f"v_num={trainer.logger.version}]",
                 flush=True,
             )
 

--- a/train.py
+++ b/train.py
@@ -43,48 +43,131 @@ class TimeLimitAfterCheckpoint(Callback):
                 f"[TimeLimit] Time limit reached ({elapsed:.1f}s), stopping after checkpoint."
             )
 
-
 class SimpleLineLogger(L.Callback):
-    def __init__(self, refresh_rate=1, metric_name="train_loss"):
+    def __init__(
+        self,
+        refresh_rate=None,
+        train_metric_step="train_loss",
+        train_metric_epoch="train_loss_epoch",
+        val_metric="val_loss_epoch",
+    ):
         super().__init__()
-        self.refresh_rate = refresh_rate
-        self.metric_name = metric_name
-        self.start_time = None
+        self.train_metric_step = train_metric_step
+        self.train_metric_epoch = train_metric_epoch
+        self.val_metric = val_metric
 
+        self.refresh_rate = refresh_rate
+
+        # Train tracking
+        self.train_start_time = None
+        self.train_last_time = None
+        self.train_last_step = 0
+
+        # Val tracking
+        self.val_start_time = None
+        self.val_last_time = None
+        self.val_last_step = 0
+
+    def _format_time(self, seconds):
+        m, s = divmod(int(seconds), 60)
+        h, m = divmod(m, 60)
+        return f"{h:02d}:{m:02d}:{s:02d}" if h else f"{m:02d}:{s:02d}"
+
+    def _get_refresh_rate(self, trainer):
+        if self.refresh_rate is not None:
+            return self.refresh_rate
+        return trainer.log_every_n_steps
+
+    # ==========================================
+    # TRAINING LOOP
+    # ==========================================
     def on_train_epoch_start(self, trainer, pl_module):
-        self.start_time = time.time()
+        self.train_start_time = time.time()
+        self.train_last_time = time.time()
+        self.train_last_step = 0
 
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
         if trainer.global_rank != 0:
             return
 
-        # Ensure we use the current step (1-indexed for display)
         current_step = batch_idx + 1
         total_batches = trainer.num_training_batches
 
-        if current_step % self.refresh_rate == 0 or current_step == total_batches:
-            elapsed = time.time() - self.start_time
+        if current_step % self._get_refresh_rate(trainer) == 0 or current_step == total_batches:
+            now = time.time()
+            elapsed_total = now - self.train_start_time
 
-            # Use tqdm.format_interval for consistent 00:00 formatting
-            elapsed_str = tqdm.format_interval(elapsed)
+            elapsed_interval = now - self.train_last_time
+            steps_interval = current_step - self.train_last_step
+            rate = steps_interval / elapsed_interval if elapsed_interval > 0 else 0
 
-            # Calculate Rate and ETA manually for total control over the string
-            rate = current_step / elapsed if elapsed > 0 else 0
             remaining = (total_batches - current_step) / rate if rate > 0 else 0
-            remaining_str = tqdm.format_interval(remaining)
-
-            metrics = trainer.callback_metrics
-            loss_val = metrics.get(self.metric_name, 0.0)
+            loss_val = trainer.callback_metrics.get(self.train_metric_step, float('nan'))
 
             print(
-                f"Epoch {trainer.current_epoch:>2}: "
+                f"Epoch {trainer.current_epoch:>2} (Train): "
                 f"{current_step / total_batches:>4.0%}| "
                 f"{current_step:>5}/{total_batches:<5} "
-                f"[{elapsed_str}<{remaining_str}, {rate:>6.2f}it/s, "
-                f"{self.metric_name}={loss_val:.5f}, "
-                f"v_num={trainer.logger.version}]",
+                f"[{self._format_time(elapsed_total)}<{self._format_time(remaining)}, "
+                f"{rate:>6.2f}it/s, "
+                f"{self.train_metric_step}={loss_val:.5f}]",
                 flush=True,
             )
+
+            self.train_last_time = now
+            self.train_last_step = current_step
+
+    # ==========================================
+    # VALIDATION LOOP
+    # ==========================================
+    def on_validation_epoch_start(self, trainer, pl_module):
+        self.val_start_time = time.time()
+        self.val_last_time = time.time()
+        self.val_last_step = 0
+
+    def on_validation_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx=0):
+        # Ignore non-zero ranks and the pre-training sanity check
+        if trainer.global_rank != 0 or trainer.sanity_checking:
+            return
+
+        current_step = batch_idx + 1
+        # Sum is used in case you have multiple validation dataloaders
+        total_batches = sum(trainer.num_val_batches)
+
+        if current_step % self._get_refresh_rate(trainer) == 0 or current_step == total_batches:
+            now = time.time()
+            elapsed_total = now - self.val_start_time
+
+            elapsed_interval = now - self.val_last_time
+            steps_interval = current_step - self.val_last_step
+            rate = steps_interval / elapsed_interval if elapsed_interval > 0 else 0
+            remaining = (total_batches - current_step) / rate if rate > 0 else 0
+
+            print(
+                f"Epoch {trainer.current_epoch:>2} (Val)  : "
+                f"{current_step / total_batches:>4.0%}| "
+                f"{current_step:>5}/{total_batches:<5} "
+                f"[{self._format_time(elapsed_total)}<{self._format_time(remaining)}, "
+                f"{rate:>6.2f}it/s]",
+                flush=True,
+            )
+
+            self.val_last_time = now
+            self.val_last_step = current_step
+
+    def on_validation_epoch_end(self, trainer, pl_module):
+        if trainer.global_rank != 0 or trainer.sanity_checking:
+            return
+
+        train_loss = trainer.callback_metrics.get(self.train_metric_epoch, float('nan'))
+        val_loss = trainer.callback_metrics.get(self.val_metric, float('nan'))
+
+        print(
+            f"Epoch {trainer.current_epoch:>2} (Summary): "
+            f"{self.train_metric_epoch}={train_loss:.5f}\n"
+            f"{self.val_metric}={val_loss:.5f}\n" + "-"*60,
+            flush=True
+        )
 
 
 def make_data_loaders(
@@ -249,6 +332,8 @@ def main():
 
     logdir = args.default_root_dir if args.default_root_dir else "logs/"
     tb_logger = pl_loggers.TensorBoardLogger(logdir)
+    csv_logger = pl_loggers.CSVLogger(logdir)
+    loggers = [tb_logger, csv_logger]
 
     if is_master_process():
         print(
@@ -302,7 +387,7 @@ def main():
         accelerator="cuda",
         strategy="ddp" if len(devices) > 1 else "auto",
         devices=devices,
-        logger=tb_logger,
+        logger=loggers,
         callbacks=[
             checkpoint_callback,
             SimpleLineLogger(refresh_rate=refresh_rate),

--- a/train.py
+++ b/train.py
@@ -282,6 +282,19 @@ def main():
     # see lightning/fabric/plugins/environments/slurm.py near line 110
     os.environ["SLURM_JOB_NAME"] = "bash"
 
+    train, val = make_data_loaders(
+        train_datasets,
+        val_datasets,
+        input_feature_name,
+        actual_workers,
+        per_gpu_batch_size,
+        args.dataloader_config,
+        args.epoch_size,
+        args.validation_size,
+        pin_memory=args.pin_memory,
+        queue_size_limit=args.data_loader_queue_size,
+    )
+
     refresh_rate = max(1, (args.num_batches_per_epoch + 4) // 5)
     trainer = L.Trainer(
         default_root_dir=logdir,
@@ -300,24 +313,11 @@ def main():
         enable_progress_bar=False,
         enable_checkpointing=True,
         benchmark=True,
-        num_sanity_val_steps=0,
+        num_sanity_val_steps=0 if val is None else 4,
     )
 
     if actual_threads > 0:
         t_set_num_threads(actual_threads)
-
-    train, val = make_data_loaders(
-        train_datasets,
-        val_datasets,
-        input_feature_name,
-        actual_workers,
-        per_gpu_batch_size,
-        args.dataloader_config,
-        args.epoch_size,
-        args.validation_size,
-        pin_memory=args.pin_memory,
-        queue_size_limit=args.data_loader_queue_size,
-    )
 
     if args.resume_from_checkpoint:
         trainer.fit(nnue, train, val, ckpt_path=args.resume_from_checkpoint)

--- a/train.py
+++ b/train.py
@@ -10,7 +10,6 @@ from torch import set_num_threads as t_set_num_threads
 from torch.utils.data import DataLoader
 from lightning.pytorch import loggers as pl_loggers
 from lightning.pytorch.callbacks import Callback, ModelCheckpoint
-from tqdm import tqdm
 
 import data_loader
 import model as M

--- a/train.py
+++ b/train.py
@@ -86,7 +86,8 @@ class SimpleLineLogger(Callback):
         self.train_last_time = time.time()
         self.train_last_step = 0
 
-        print("-"*60)
+        if trainer.global_rank == 0:
+            print("-"*60)
 
     @torch.compiler.disable
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):

--- a/train.py
+++ b/train.py
@@ -42,7 +42,7 @@ class TimeLimitAfterCheckpoint(Callback):
                 f"[TimeLimit] Time limit reached ({elapsed:.1f}s), stopping after checkpoint."
             )
 
-class SimpleLineLogger(L.Callback):
+class SimpleLineLogger(Callback):
     def __init__(
         self,
         refresh_rate=None,
@@ -80,11 +80,15 @@ class SimpleLineLogger(L.Callback):
     # ==========================================
     # TRAINING LOOP
     # ==========================================
+    @torch.compiler.disable
     def on_train_epoch_start(self, trainer, pl_module):
         self.train_start_time = time.time()
         self.train_last_time = time.time()
         self.train_last_step = 0
 
+        print("-"*60)
+
+    @torch.compiler.disable
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
         if trainer.global_rank != 0:
             return
@@ -116,6 +120,7 @@ class SimpleLineLogger(L.Callback):
             self.train_last_time = now
             self.train_last_step = current_step
 
+    @torch.compiler.disable
     def on_train_epoch_end(self, trainer, pl_module):
         if trainer.global_rank != 0 or trainer.sanity_checking:
             return
@@ -123,18 +128,20 @@ class SimpleLineLogger(L.Callback):
         train_loss = trainer.callback_metrics.get(self.train_metric_epoch, float('nan'))
         print(
             f"Epoch {trainer.current_epoch:>2} (Train): "
-            f"[{self.train_metric_epoch}={train_loss:.5f}]\n" + "-"*60,
+            f"[{self.train_metric_epoch}={train_loss:.5f}]",
             flush=True
         )
 
     # ==========================================
     # VALIDATION LOOP
     # ==========================================
+    @torch.compiler.disable
     def on_validation_epoch_start(self, trainer, pl_module):
         self.val_start_time = time.time()
         self.val_last_time = time.time()
         self.val_last_step = 0
 
+    @torch.compiler.disable
     def on_validation_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx=0):
         # Ignore non-zero ranks and the pre-training sanity check
         if trainer.global_rank != 0 or trainer.sanity_checking:
@@ -165,6 +172,7 @@ class SimpleLineLogger(L.Callback):
             self.val_last_time = now
             self.val_last_step = current_step
 
+    @torch.compiler.disable
     def on_validation_epoch_end(self, trainer, pl_module):
         if trainer.global_rank != 0 or trainer.sanity_checking:
             return
@@ -172,7 +180,7 @@ class SimpleLineLogger(L.Callback):
         val_loss = trainer.callback_metrics.get(self.val_metric, float('nan'))
         print(
             f"Epoch {trainer.current_epoch:>2} (Val): "
-            f"[{self.val_metric}={val_loss:.5f}]\n" + "-"*60,
+            f"[{self.val_metric}={val_loss:.5f}]",
             flush=True
         )
 
@@ -371,6 +379,8 @@ def main():
         save_top_k=-1,
     )
 
+    # Since we compile the entire lighning module we have quite a few graph breaks
+    torch._dynamo.config.cache_size_limit = 32
     nnue = torch.compile(nnue, backend=args.compile_backend)
     # PL hack, undo slurm cluster detection which is broken for us. 'force interactive mode'
     # see lightning/fabric/plugins/environments/slurm.py near line 110

--- a/train.py
+++ b/train.py
@@ -108,7 +108,7 @@ class SimpleLineLogger(Callback):
                 f"{current_step:>5}/{total_batches:<5} "
                 f"[{self._format_time(elapsed_total)}<{self._format_time(remaining)}, "
                 f"{rate:>6.2f}it/s, "
-                f"{self.train_metric_step}={loss_val:.5f}]",
+                f"{self.train_metric_step}={loss_val:.5f}, ",
                 f"v_num={trainer.logger.version}]",
                 flush=True,
             )
@@ -143,7 +143,11 @@ class SimpleLineLogger(Callback):
             return
 
         current_step = batch_idx + 1
-        total_batches = sum(trainer.num_val_batches)
+        val_batches = trainer.num_val_batches
+        if isinstance(val_batches, int):
+            total_batches = val_batches
+        else:
+            total_batches = sum(val_batches)
 
         if current_step % self._get_refresh_rate(trainer) == 0 or current_step == total_batches:
             now = time.time()
@@ -212,7 +216,17 @@ def make_data_loaders(
     if val_size <= 0:
         val = None
     elif val_filenames is None:
-        val = train
+        val = DataLoader(
+            data_loader.FixedNumBatchesDataset(
+                train_infinite,
+                (val_size + batch_size - 1) // batch_size,
+                pin_memory=pin_memory,
+                queue_size_limit=queue_size_limit,
+            ),
+            batch_size=None,
+            batch_sampler=None,
+            num_workers=0,
+        )
     else:
         val_infinite = data_loader.SparseBatchDataset(
             features_name,
@@ -369,7 +383,7 @@ def main():
         save_top_k=-1,
     )
 
-    # Since we compile the entire lighning module we have quite a few graph breaks
+    # Since we compile the entire lightning module we have quite a few graph breaks
     torch._dynamo.config.cache_size_limit = 32
     nnue = torch.compile(nnue, backend=args.compile_backend)
     # PL hack, undo slurm cluster detection which is broken for us. 'force interactive mode'

--- a/train.py
+++ b/train.py
@@ -332,7 +332,7 @@ def main():
 
     logdir = args.default_root_dir if args.default_root_dir else "logs/"
     tb_logger = pl_loggers.TensorBoardLogger(logdir)
-    csv_logger = pl_loggers.CSVLogger(logdir)
+    csv_logger = pl_loggers.CSVLogger(logdir, version=tb_logger.version)
     loggers = [tb_logger, csv_logger]
 
     if is_master_process():

--- a/train.py
+++ b/train.py
@@ -116,6 +116,17 @@ class SimpleLineLogger(L.Callback):
             self.train_last_time = now
             self.train_last_step = current_step
 
+    def on_train_epoch_end(self, trainer, pl_module):
+        if trainer.global_rank != 0 or trainer.sanity_checking:
+            return
+
+        train_loss = trainer.callback_metrics.get(self.train_metric_epoch, float('nan'))
+        print(
+            f"Epoch {trainer.current_epoch:>2} (Train): "
+            f"[{self.train_metric_epoch}={train_loss:.5f}]\n" + "-"*60,
+            flush=True
+        )
+
     # ==========================================
     # VALIDATION LOOP
     # ==========================================
@@ -158,13 +169,10 @@ class SimpleLineLogger(L.Callback):
         if trainer.global_rank != 0 or trainer.sanity_checking:
             return
 
-        train_loss = trainer.callback_metrics.get(self.train_metric_epoch, float('nan'))
         val_loss = trainer.callback_metrics.get(self.val_metric, float('nan'))
-
         print(
-            f"Epoch {trainer.current_epoch:>2} (Summary): "
-            f"[{self.train_metric_epoch}={train_loss:.5f}, "
-            f"{self.val_metric}={val_loss:.5f}]\n" + "-"*60,
+            f"Epoch {trainer.current_epoch:>2} (Val): "
+            f"[{self.val_metric}={val_loss:.5f}]\n" + "-"*60,
             flush=True
         )
 
@@ -205,6 +213,8 @@ def make_data_loaders(
     )
     if val_size <= 0:
         val = None
+    elif val_filenames is None:
+        val = train
     else:
         val_infinite = data_loader.SparseBatchDataset(
             features_name,
@@ -244,7 +254,7 @@ def main():
             raise Exception("{0} does not exist".format(val_dataset))
 
     train_datasets = args.datasets
-    val_datasets = train_datasets
+    val_datasets = None
 
     if len(args.validation_datasets) > 0:
         val_datasets = args.validation_datasets

--- a/train.py
+++ b/train.py
@@ -121,6 +121,7 @@ class SimpleLineLogger(Callback):
         if trainer.global_rank != 0 or trainer.sanity_checking:
             return
 
+        pl_module._log_epoch_end(self.train_metric_epoch)
         train_loss = trainer.callback_metrics.get(self.train_metric_epoch, float('nan'))
         print(
             f"Epoch {trainer.current_epoch:>2} (Train): "
@@ -165,6 +166,7 @@ class SimpleLineLogger(Callback):
         if trainer.global_rank != 0 or trainer.sanity_checking:
             return
 
+        pl_module._log_epoch_end(self.val_metric)
         val_loss = trainer.callback_metrics.get(self.val_metric, float('nan'))
         print(
             f"Epoch {trainer.current_epoch:>2} (Val): "

--- a/train.py
+++ b/train.py
@@ -163,8 +163,8 @@ class SimpleLineLogger(L.Callback):
 
         print(
             f"Epoch {trainer.current_epoch:>2} (Summary): "
-            f"{self.train_metric_epoch}={train_loss:.5f}\n"
-            f"{self.val_metric}={val_loss:.5f}\n" + "-"*60,
+            f"[{self.train_metric_epoch}={train_loss:.5f}, "
+            f"{self.val_metric}={val_loss:.5f}]\n" + "-"*60,
             flush=True
         )
 

--- a/train.py
+++ b/train.py
@@ -82,11 +82,8 @@ class SimpleLineLogger(Callback):
     # ==========================================
     @torch.compiler.disable
     def on_train_epoch_start(self, trainer, pl_module):
-        self.train_start_time = time.time()
-        self.train_last_time = time.time()
-        self.train_last_step = 0
-
         if trainer.global_rank == 0:
+            self.train_start_time = time.time()
             print("-"*60)
 
     @torch.compiler.disable
@@ -100,10 +97,7 @@ class SimpleLineLogger(Callback):
         if current_step % self._get_refresh_rate(trainer) == 0 or current_step == total_batches:
             now = time.time()
             elapsed_total = now - self.train_start_time
-
-            elapsed_interval = now - self.train_last_time
-            steps_interval = current_step - self.train_last_step
-            rate = steps_interval / elapsed_interval if elapsed_interval > 0 else 0
+            rate = current_step / elapsed_total if elapsed_total > 0 else 0
 
             remaining = (total_batches - current_step) / rate if rate > 0 else 0
             loss_val = trainer.callback_metrics.get(self.train_metric_step, float('nan'))
@@ -139,27 +133,22 @@ class SimpleLineLogger(Callback):
     # ==========================================
     @torch.compiler.disable
     def on_validation_epoch_start(self, trainer, pl_module):
-        self.val_start_time = time.time()
-        self.val_last_time = time.time()
-        self.val_last_step = 0
+        if trainer.global_rank == 0 and not trainer.sanity_checking:
+            self.val_start_time = time.time()
 
     @torch.compiler.disable
     def on_validation_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx=0):
-        # Ignore non-zero ranks and the pre-training sanity check
         if trainer.global_rank != 0 or trainer.sanity_checking:
             return
 
         current_step = batch_idx + 1
-        # Sum is used in case you have multiple validation dataloaders
         total_batches = sum(trainer.num_val_batches)
 
         if current_step % self._get_refresh_rate(trainer) == 0 or current_step == total_batches:
             now = time.time()
             elapsed_total = now - self.val_start_time
 
-            elapsed_interval = now - self.val_last_time
-            steps_interval = current_step - self.val_last_step
-            rate = steps_interval / elapsed_interval if elapsed_interval > 0 else 0
+            rate = current_step / elapsed_total if elapsed_total > 0 else 0
             remaining = (total_batches - current_step) / rate if rate > 0 else 0
 
             print(
@@ -170,9 +159,6 @@ class SimpleLineLogger(Callback):
                 f"{rate:>6.2f}it/s]",
                 flush=True,
             )
-
-            self.val_last_time = now
-            self.val_last_step = current_step
 
     @torch.compiler.disable
     def on_validation_epoch_end(self, trainer, pl_module):


### PR DESCRIPTION
#440 removed the logging of validation. While we almost never use validation it can be useful for debugging edge cases or when using optimizers different than ranger21.

This PR expands the SimpleLineLogger to also log validation metric (i.e. validation loss).

Additionally it uses `dist_sync=False` for `on_step` logging to reduce overhead. To make up for it, it uses on_epoch logging with `dist_sync=True`. This is also more informative for the most people as single batch values can be very noisy.

Lastly I added the lightweight `csv_logger` additionally to the tb_logger. I have never used the tb_logger myself but I think for most a simple csv file is easier to handle