### PR TITLE
Quant fix

### DIFF
--- a/cross_check_eval.py
+++ b/cross_check_eval.py
@@ -186,14 +186,12 @@ def main():
             args.checkpoint,
             feature_name=feature_name,
             config=ModelConfig.get_model_config(args),
-            quantize_config=QuantizationConfig(),
         )
     else:
         model = read_model(
             args.net,
             feature_name,
             ModelConfig.get_model_config(args),
-            QuantizationConfig(),
         )
     model.eval()
     input_feature_name = model.model.input_feature_name

--- a/ftperm.py
+++ b/ftperm.py
@@ -676,7 +676,6 @@ def command_gather(args: FeaturePermutationConfig) -> None:
             args.subcommand.checkpoint,
             feature_name=args.feature_config.features,
             config=args.model_config,
-            quantize_config=QuantizationConfig(),
         )
         model = nnue.model
     else:
@@ -685,7 +684,6 @@ def command_gather(args: FeaturePermutationConfig) -> None:
             args.subcommand.net,
             args.feature_config.features,
             args.model_config,
-            QuantizationConfig(),
         )
 
     model.eval()

--- a/model/config.py
+++ b/model/config.py
@@ -34,7 +34,7 @@ class ModelConfig(LayerStacksConfig):
         config.L2 = args.L2
         return config
 
-    # Not ommiting prefix on purpose.
+    # Not omitting prefix on purpose.
     quantize_config: QuantizationConfig = field(default_factory=QuantizationConfig)
 
 

--- a/model/config.py
+++ b/model/config.py
@@ -4,6 +4,7 @@ from typing import Annotated
 import tyro
 from tyro.conf import OmitArgPrefixes
 
+from .quantize import QuantizationConfig
 from .optimizers import OptimizerConfig
 from .modules import FeatureConfig, LayerStacksConfig
 
@@ -32,6 +33,9 @@ class ModelConfig(LayerStacksConfig):
         config.L1 = args.L1
         config.L2 = args.L2
         return config
+
+    # Not ommiting prefix on purpose.
+    quantize_config: QuantizationConfig = field(default_factory=QuantizationConfig)
 
 
 # parameters needed for the definition of the loss

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -5,7 +5,6 @@ from torchmetrics import MeanMetric, MetricCollection
 
 from .config import NNUELightningConfig
 from .model import NNUEModel
-from .quantize import QuantizationConfig
 
 
 def _get_parameters(layers: list[nn.Module], get_biases: bool = False):
@@ -29,7 +28,6 @@ class NNUE(L.LightningModule):
         config: NNUELightningConfig,
         max_epoch=None,
         num_batches_per_epoch=None,
-        quantize_config=QuantizationConfig(),
         param_index=0,
         num_psqt_buckets=8,
         num_ls_buckets=8,
@@ -39,7 +37,6 @@ class NNUE(L.LightningModule):
         self.model: NNUEModel = NNUEModel(
             config.features,
             config.model_config,
-            quantize_config,
             num_psqt_buckets,
             num_ls_buckets,
         )

--- a/model/model.py
+++ b/model/model.py
@@ -11,7 +11,6 @@ class NNUEModel(nn.Module):
         self,
         feature_name: str,
         config: ModelConfig,
-        quantize_config: QuantizationConfig,
         num_psqt_buckets: int = 8,
         num_ls_buckets: int = 8,
     ):
@@ -31,7 +30,7 @@ class NNUEModel(nn.Module):
         self.feature_hash = self.input.HASH
         self.layer_stacks = LayerStacks(self.num_ls_buckets, config)
 
-        self.quantization = QuantizationManager(quantize_config)
+        self.quantization = QuantizationManager(config.quantize_config)
         self.weight_clipping = self.quantization.generate_weight_clipping_config(self)
 
         self.input.init_weights(num_psqt_buckets, self.quantization.nnue2score)

--- a/model/model.py
+++ b/model/model.py
@@ -3,7 +3,7 @@ from torch import nn
 
 from .config import ModelConfig
 from .modules import LayerStacks, get_feature_cls
-from .quantize import QuantizationConfig, QuantizationManager
+from .quantize import QuantizationManager
 
 
 class NNUEModel(nn.Module):
@@ -21,6 +21,9 @@ class NNUEModel(nn.Module):
         self.L2 = config.L2
         self.L3 = config.L3
 
+        self.quantize_config = config.quantize_config
+        self.quantization = QuantizationManager(config.quantize_config)
+
         self.num_psqt_buckets = num_psqt_buckets
         self.num_ls_buckets = num_ls_buckets
 
@@ -28,9 +31,8 @@ class NNUEModel(nn.Module):
         self.feature_name = self.input.FEATURE_NAME
         self.input_feature_name = self.input.INPUT_FEATURE_NAME
         self.feature_hash = self.input.HASH
-        self.layer_stacks = LayerStacks(self.num_ls_buckets, config)
+        self.layer_stacks = LayerStacks(self.num_ls_buckets, config, self.quantization)
 
-        self.quantization = QuantizationManager(config.quantize_config)
         self.weight_clipping = self.quantization.generate_weight_clipping_config(self)
 
         self.input.init_weights(num_psqt_buckets, self.quantization.nnue2score)
@@ -82,13 +84,12 @@ class NNUEModel(nn.Module):
         w, wpsqt = torch.split(wp, self.L1, dim=1)
         b, bpsqt = torch.split(bp, self.L1, dim=1)
         l0_ = (us * torch.cat([w, b], dim=1)) + (them * torch.cat([b, w], dim=1))
-        l0_ = torch.clamp(l0_, 0.0, 1.0)
+        l0_ = torch.clamp(l0_, 0.0, self.quantization.max_ft_activation)
 
         l0_s = torch.split(l0_, self.L1 // 2, dim=1)
         l0_s1 = [l0_s[0] * l0_s[1], l0_s[2] * l0_s[3]]
-        # We multiply by 127/128 because in the quantized network 1.0 is represented by 127
-        # and it's more efficient to divide by 128 instead.
-        l0_ = torch.cat(l0_s1, dim=1) * (127 / 128)
+        # We multiply by a correction factor, so we can use only bitshift and multiplication at inference.
+        l0_ = torch.cat(l0_s1, dim=1) * self.quantization.l0_correction_factor
 
         psqt_indices_unsq = psqt_indices.unsqueeze(dim=1)
         wpsqt = wpsqt.gather(1, psqt_indices_unsq)

--- a/model/modules/layer_stacks.py
+++ b/model/modules/layer_stacks.py
@@ -33,7 +33,7 @@ class LayerStacks(nn.Module):
         l1x_, l1x_out = l1c_.split(self.L2, dim=1)
         # multiply sqr crelu result by scale correction to match quantized version
         l1x_ = torch.clamp(
-            torch.cat([torch.pow(l1x_, 2.0) * (self.quantization.sqcrele_correction_factor), l1x_], dim=1),
+            torch.cat([torch.pow(l1x_, 2.0) * (self.quantization.sqr_crelu_correction_factor), l1x_], dim=1),
             0.0,
             self.quantization.max_hidden_activation,
         )

--- a/model/modules/layer_stacks.py
+++ b/model/modules/layer_stacks.py
@@ -1,20 +1,21 @@
-from typing import Generator
+from typing import Generator, TYPE_CHECKING
 
 import torch
 from torch import nn
 
 from .stacked_linear import FactorizedStackedLinear, StackedLinear
 from .config import LayerStacksConfig
-
+from ..quantize import QuantizationManager
 
 class LayerStacks(nn.Module):
-    def __init__(self, count: int, config: LayerStacksConfig):
+    def __init__(self, count: int, config: LayerStacksConfig, quantization: QuantizationManager):
         super().__init__()
 
         self.count = count
         self.L1 = config.L1
         self.L2 = config.L2
         self.L3 = config.L3
+        self.quantization = quantization
 
         # Factorizer only for the first layer because later
         # there's a non-linearity and factorization breaks.
@@ -30,13 +31,15 @@ class LayerStacks(nn.Module):
     def forward(self, x: torch.Tensor, ls_indices: torch.Tensor):
         l1c_ = self.l1(x, ls_indices)
         l1x_, l1x_out = l1c_.split(self.L2, dim=1)
-        # multiply sqr crelu result by (255/256) to match quantized version
+        # multiply sqr crelu result by scale correction to match quantized version
         l1x_ = torch.clamp(
-            torch.cat([torch.pow(l1x_, 2.0) * (255 / 256), l1x_], dim=1), 0.0, 1.0
+            torch.cat([torch.pow(l1x_, 2.0) * (self.quantization.sqcrele_correction_factor), l1x_], dim=1),
+            0.0,
+            self.quantization.max_hidden_activation,
         )
 
         l2c_ = self.l2(l1x_, ls_indices)
-        l2x_ = torch.clamp(l2c_, 0.0, 1.0)
+        l2x_ = torch.clamp(l2c_, 0.0, self.quantization.max_hidden_activation)
 
         l3c_ = self.output(l2x_, ls_indices)
         l3x_ = l3c_ + l1x_out

--- a/model/modules/layer_stacks.py
+++ b/model/modules/layer_stacks.py
@@ -1,4 +1,4 @@
-from typing import Generator, TYPE_CHECKING
+from typing import Generator
 
 import torch
 from torch import nn

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -28,7 +28,7 @@ def _safe_convert(value: torch.Tensor, target_dtype: torch.dtype):
 @dataclass
 class QuantizationConfig:
     nnue2score: float = 600.0
-    weight_scale_hidden_0: float = 64.0
+    weight_scale_hidden_0: float = 128.0
     weight_scale_hidden_1: float = 64.0
     weight_scale_hidden_2: float = 128.0
     weight_scale_out: float = 16.0

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -13,6 +13,17 @@ class WeightClippingConfig(TypedDict):
     max_weight: float
     virtual_params: NotRequired[torch.Tensor]
 
+def _safe_convert(value: torch.Tensor, target_dtype: torch.dtype):
+    _info = torch.iinfo(target_dtype)
+    # Symmetric range: [-max, max]
+    min_val = -_info.max
+    max_val = _info.max
+
+    rounded_value = value.round()
+    clamped_value = rounded_value.clamp(min_val, max_val)
+    num_clipped = (rounded_value != clamped_value).sum()
+    quantized_value = clamped_value.to(target_dtype)
+    return quantized_value, num_clipped
 
 @dataclass
 class QuantizationConfig:
@@ -87,36 +98,26 @@ class QuantizationManager:
             },
         ]
 
-    def _safe_convert(self, value, target_dtype):
-        _info = torch.iinfo(target_dtype)
-        # Symmetric range: [-max, max]
-        min_val = -_info.max
-        max_val = _info.max
-
-        rounded_value = value.round()
-        clamped_value = rounded_value.clamp(min_val, max_val)
-        num_clipped = (rounded_value != clamped_value).sum()
-        quantized_value = clamped_value.to(target_dtype)
-        return quantized_value, num_clipped
-
     def quantize_feature_transformer(
         self,
         bias: torch.Tensor,
         weight: torch.Tensor,
         psqt_weight: torch.Tensor,
+        f_weight_export_dtype: torch.dtype = torch.int16,
         callback: Optional[Callable] = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
         psqt_weight = psqt_weight.mul(self.nnue2score * self.weight_scale_out)
         bias = bias.mul(self.ft_quantized_one)
         weight = weight.mul(self.ft_quantized_one)
 
-        bias, bias_clipped = self._safe_convert(bias, torch.int16)
-        weight, weight_clipped = self._safe_convert(weight, torch.int16)
-        psqt_weight, psqt_weight_clipped = self._safe_convert(psqt_weight, torch.int32)
+         # only weight can have different dtypes, bias is always int16, psqt_weight is always int32
+        bias, bias_clipped = _safe_convert(bias, torch.int16)
+        weight, weight_clipped = _safe_convert(weight, f_weight_export_dtype)
+        psqt_weight, psqt_weight_clipped = _safe_convert(psqt_weight, torch.int32)
 
         if callback is not None:
-            callback("fc_weight", weight, weight_clipped)
-            callback("fc_bias", bias, bias_clipped)
+            callback("fct_weight", weight, weight_clipped)
+            callback("ft_bias", bias, bias_clipped)
             callback("psqt_weight", psqt_weight, psqt_weight_clipped)
 
         return bias, weight, psqt_weight
@@ -142,8 +143,8 @@ class QuantizationManager:
         kBiasScaleHidden = self.weight_scale_hidden * self.hidden_quantized_one
         kWeightScaleHidden = self.weight_scale_hidden
 
-        bias, bias_clipped = self._safe_convert(bias.mul(kBiasScaleHidden), torch.int32)
-        weight, weight_clipped = self._safe_convert(weight.mul(kWeightScaleHidden), torch.int8)
+        bias, bias_clipped = _safe_convert(bias.mul(kBiasScaleHidden), torch.int32)
+        weight, weight_clipped = _safe_convert(weight.mul(kWeightScaleHidden), torch.int8)
 
         if callback is not None:
             callback("fc_weight", weight, weight_clipped)

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Callable, NotRequired, TypedDict, TYPE_CHECKING
+from typing import Optional, Callable, NotRequired, TypedDict, TYPE_CHECKING
 
 import torch
 
@@ -19,10 +19,11 @@ class QuantizationConfig:
     nnue2score: float = 600.0
     weight_scale_hidden: float = 64.0
     weight_scale_out: float = 16.0
+    weight_quantized_max_hidden: float = 127.0 # i8 max
     ft_quantized_one: float = 256.0
-    ft_quantized_max: float = 255.0
+    ft_quantized_max: float = 255.0 # limited to 255 for safe squaring withing i16
     hidden_quantized_one: float = 128.0
-    hidden_quantized_max: float = 127.0
+    hidden_quantized_max: float = 127.0 # i8 max
     inference_l0_division_factor: float = 512.0
     inference_sqcrele_division_factor: float = 128.0
 
@@ -31,14 +32,17 @@ class QuantizationManager:
         self.nnue2score = config.nnue2score
         self.weight_scale_hidden = config.weight_scale_hidden
         self.weight_scale_out = config.weight_scale_out
+        self.weight_quantized_max_hidden = config.weight_quantized_max_hidden
         self.hidden_quantized_one = config.hidden_quantized_one
         self.ft_quantized_one = config.ft_quantized_one
 
-        self.max_hidden_weight = config.hidden_quantized_one / config.weight_scale_hidden
+        hidden_q_max = config.weight_quantized_max_hidden
+        self.max_hidden_weight = hidden_q_max / config.weight_scale_hidden
+        # Thread weights are treated separately. A bit hacky...
         # Threat weights are quantized to int8 after scaling by ft_quantized_one
         _i8 = torch.iinfo(torch.int8)
-        self.min_threat_weight = -_i8.max / config.ft_quantized_one  # -127/255
-        self.max_threat_weight = _i8.max / config.ft_quantized_one  # 127/255
+        self.min_threat_weight = -_i8.max / config.ft_quantized_one  # -127/256
+        self.max_threat_weight = _i8.max / config.ft_quantized_one  # 127/256
 
         self._l0_correction_factor = config.ft_quantized_one ** 2 / config.inference_l0_division_factor / self.hidden_quantized_one
         self._sqcrele_correction_factor = config.hidden_quantized_one / config.inference_sqcrele_division_factor
@@ -85,27 +89,35 @@ class QuantizationManager:
 
     def _safe_convert(self, value, target_dtype):
         _info = torch.iinfo(target_dtype)
+        # Symmetric range: [-max, max]
         min_val = -_info.max
         max_val = _info.max
 
-        return value.clamp(min_val, max_val).round().to(target_dtype)
+        rounded_value = value.round()
+        clamped_value = rounded_value.clamp(min_val, max_val)
+        num_clipped = (rounded_value != clamped_value).sum()
+        quantized_value = clamped_value.to(target_dtype)
+        return quantized_value, num_clipped
 
     def quantize_feature_transformer(
         self,
         bias: torch.Tensor,
         weight: torch.Tensor,
         psqt_weight: torch.Tensor,
-        callback: Callable = lambda *args, **kwargs: None,
+        callback: Optional[Callable] = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        bias = bias.mul(self.ft_quantized_one).round().to(torch.int16)
-        weight = weight.mul(self.ft_quantized_one).round().to(torch.int16)
-        psqt_weight = (
-            psqt_weight.mul(self.nnue2score * self.weight_scale_out)
-            .round()
-            .to(torch.int32)
-        )
+        psqt_weight = psqt_weight.mul(self.nnue2score * self.weight_scale_out)
+        bias = bias.mul(self.ft_quantized_one)
+        weight = weight.mul(self.ft_quantized_one)
 
-        callback(bias, weight, psqt_weight)
+        bias, bias_clipped = self._safe_convert(bias, torch.int16)
+        weight, weight_clipped = self._safe_convert(weight, torch.int16)
+        psqt_weight, psqt_weight_clipped = self._safe_convert(psqt_weight, torch.int32)
+
+        if callback is not None:
+            callback("fc_weight", weight, weight_clipped)
+            callback("fc_bias", bias, bias_clipped)
+            callback("psqt_weight", psqt_weight, psqt_weight_clipped)
 
         return bias, weight, psqt_weight
 
@@ -125,30 +137,18 @@ class QuantizationManager:
         self,
         bias: torch.Tensor,
         weight: torch.Tensor,
-        callback: Callable = lambda *args, **kwargs: None,
+        callback: Optional[Callable] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        kWeightScaleHidden = self.weight_scale_hidden
-        kWeightScale = kWeightScaleHidden
         kBiasScaleHidden = self.weight_scale_hidden * self.hidden_quantized_one
-        kBiasScale = kBiasScaleHidden
-        kMaxWeight = self.hidden_quantized_one / kWeightScale
+        kWeightScaleHidden = self.weight_scale_hidden
+        kMaxWeight = self.max_hidden_weight
 
-        bias = bias.mul(kBiasScale).round().to(torch.int32)
+        bias, bias_clipped = self._safe_convert(bias.mul(kBiasScaleHidden), torch.int32)
+        weight, weight_clipped = self._safe_convert(weight.mul(kWeightScaleHidden), torch.int8)
 
-        clipped = torch.count_nonzero(weight.clamp(-kMaxWeight, kMaxWeight) - weight)
-        total_elements = torch.numel(weight)
-        clipped_max = torch.max(
-            torch.abs(weight.clamp(-kMaxWeight, kMaxWeight) - weight)
-        )
-
-        weight = (
-            weight.clamp(-kMaxWeight, kMaxWeight)
-            .mul(kWeightScale)
-            .round()
-            .to(torch.int8)
-        )
-
-        callback(bias, weight, clipped, total_elements, clipped_max, kMaxWeight)
+        if callback is not None:
+            callback("fc_weight", weight, weight_clipped)
+            callback("fc_bias", bias, bias_clipped)
 
         return bias, weight
 

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -28,7 +28,9 @@ def _safe_convert(value: torch.Tensor, target_dtype: torch.dtype):
 @dataclass
 class QuantizationConfig:
     nnue2score: float = 600.0
-    weight_scale_hidden: float = 64.0
+    weight_scale_hidden_0: float = 64.0
+    weight_scale_hidden_1: float = 64.0
+    weight_scale_hidden_2: float = 128.0
     weight_scale_out: float = 16.0
     weight_quantized_max_hidden: float = 127.0 # i8 max
     ft_quantized_one: float = 256.0
@@ -41,14 +43,18 @@ class QuantizationConfig:
 class QuantizationManager:
     def __init__(self, config: QuantizationConfig):
         self.nnue2score = config.nnue2score
-        self.weight_scale_hidden = config.weight_scale_hidden
+        self.weight_scale_hidden = [
+            config.weight_scale_hidden_0,
+            config.weight_scale_hidden_1,
+            config.weight_scale_hidden_2,
+        ]
         self.weight_scale_out = config.weight_scale_out
         self.weight_quantized_max_hidden = config.weight_quantized_max_hidden
         self.hidden_quantized_one = config.hidden_quantized_one
         self.ft_quantized_one = config.ft_quantized_one
 
         hidden_q_max = config.weight_quantized_max_hidden
-        self.max_hidden_weight = hidden_q_max / config.weight_scale_hidden
+        self.max_hidden_weight = [hidden_q_max / scale for scale in self.weight_scale_hidden]
         # Thread weights are treated separately. A bit hacky...
         # Threat weights are quantized to int8 after scaling by ft_quantized_one
         _i8 = torch.iinfo(torch.int8)
@@ -82,19 +88,19 @@ class QuantizationManager:
         return [
             {
                 "params": [model.layer_stacks.l1.linear.weight],
-                "min_weight": -self.max_hidden_weight,
-                "max_weight": self.max_hidden_weight,
+                "min_weight": -self.max_hidden_weight[0],
+                "max_weight": self.max_hidden_weight[0],
                 "virtual_params": model.layer_stacks.l1.factorized_linear.weight,
             },
             {
                 "params": [model.layer_stacks.l2.linear.weight],
-                "min_weight": -self.max_hidden_weight,
-                "max_weight": self.max_hidden_weight,
+                "min_weight": -self.max_hidden_weight[1],
+                "max_weight": self.max_hidden_weight[1],
             },
             {
                 "params": [model.layer_stacks.output.linear.weight],
-                "min_weight": -self.max_hidden_weight,
-                "max_weight": self.max_hidden_weight,
+                "min_weight": -self.max_hidden_weight[2],
+                "max_weight": self.max_hidden_weight[2],
             },
         ]
 
@@ -138,10 +144,11 @@ class QuantizationManager:
         self,
         bias: torch.Tensor,
         weight: torch.Tensor,
+        layer_idx: int,
         callback: Optional[Callable] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        kBiasScaleHidden = self.weight_scale_hidden * self.hidden_quantized_one
-        kWeightScaleHidden = self.weight_scale_hidden
+        kBiasScaleHidden = self.weight_scale_hidden[layer_idx] * self.hidden_quantized_one
+        kWeightScaleHidden = self.weight_scale_hidden[layer_idx]
 
         bias, bias_clipped = _safe_convert(bias.mul(kBiasScaleHidden), torch.int32)
         weight, weight_clipped = _safe_convert(weight.mul(kWeightScaleHidden), torch.int8)
@@ -156,9 +163,10 @@ class QuantizationManager:
         self,
         bias: torch.Tensor,
         weight: torch.Tensor,
+        layer_idx: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        kBiasScaleHidden = self.weight_scale_hidden * self.hidden_quantized_one
-        kWeightScaleHidden = self.weight_scale_hidden
+        kBiasScaleHidden = self.weight_scale_hidden[layer_idx] * self.hidden_quantized_one
+        kWeightScaleHidden = self.weight_scale_hidden[layer_idx]
 
         bias = bias.divide(kBiasScaleHidden)
         weight = weight.divide(kWeightScaleHidden)

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -34,11 +34,11 @@ class QuantizationConfig:
     weight_scale_out: float = 16.0
     weight_quantized_max_hidden: float = 127.0 # i8 max
     ft_quantized_one: float = 256.0
-    ft_quantized_max: float = 255.0 # limited to 255 for safe squaring withing i16
+    ft_quantized_max: float = 255.0 # limited to 255 for safe squaring within i16
     hidden_quantized_one: float = 128.0
     hidden_quantized_max: float = 127.0 # i8 max
     inference_l0_division_factor: float = 512.0
-    inference_sqcrele_division_factor: float = 128.0
+    inference_sqr_crelu_division_factor: float = 128.0
 
 class QuantizationManager:
     def __init__(self, config: QuantizationConfig):
@@ -55,14 +55,14 @@ class QuantizationManager:
 
         hidden_q_max = config.weight_quantized_max_hidden
         self.max_hidden_weight = [hidden_q_max / scale for scale in self.weight_scale_hidden]
-        # Thread weights are treated separately. A bit hacky...
+        # Threat weights are treated separately. A bit hacky...
         # Threat weights are quantized to int8 after scaling by ft_quantized_one
         _i8 = torch.iinfo(torch.int8)
         self.min_threat_weight = -_i8.max / config.ft_quantized_one  # -127/256
         self.max_threat_weight = _i8.max / config.ft_quantized_one  # 127/256
 
         self._l0_correction_factor = config.ft_quantized_one ** 2 / config.inference_l0_division_factor / self.hidden_quantized_one
-        self._sqcrele_correction_factor = config.hidden_quantized_one / config.inference_sqcrele_division_factor
+        self._sqr_crelu_correction_factor = config.hidden_quantized_one / config.inference_sqr_crelu_division_factor
         self._max_ft_activation = config.ft_quantized_max / config.ft_quantized_one
         self._max_hidden_activation = config.hidden_quantized_max / config.hidden_quantized_one
 
@@ -71,8 +71,8 @@ class QuantizationManager:
         return self._l0_correction_factor
 
     @property
-    def sqcrele_correction_factor(self):
-        return self._sqcrele_correction_factor
+    def sqr_crelu_correction_factor(self):
+        return self._sqr_crelu_correction_factor
 
     @property
     def max_ft_activation(self):
@@ -106,9 +106,9 @@ class QuantizationManager:
 
     def quantize_feature_transformer(
         self,
-        bias: torch.Tensor,
-        weight: torch.Tensor,
-        psqt_weight: torch.Tensor,
+        bias: Optional[torch.Tensor],
+        weight: Optional[torch.Tensor],
+        psqt_weight: Optional[torch.Tensor],
         f_weight_export_dtype: torch.dtype = torch.int16,
         callback: Optional[Callable] = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -141,7 +141,6 @@ class QuantizationManager:
     ) -> tuple[torch.Tensor, torch.Tensor]:
         kBiasScaleHidden = self.weight_scale_hidden * self.hidden_quantized_one
         kWeightScaleHidden = self.weight_scale_hidden
-        kMaxWeight = self.max_hidden_weight
 
         bias, bias_clipped = self._safe_convert(bias.mul(kBiasScaleHidden), torch.int32)
         weight, weight_clipped = self._safe_convert(weight.mul(kWeightScaleHidden), torch.int8)
@@ -157,12 +156,10 @@ class QuantizationManager:
         bias: torch.Tensor,
         weight: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        kWeightScaleHidden = self.weight_scale_hidden
-        kWeightScale = kWeightScaleHidden
         kBiasScaleHidden = self.weight_scale_hidden * self.hidden_quantized_one
-        kBiasScale = kBiasScaleHidden
+        kWeightScaleHidden = self.weight_scale_hidden
 
-        bias = bias.divide(kBiasScale)
-        weight = weight.divide(kWeightScale)
+        bias = bias.divide(kBiasScaleHidden)
+        weight = weight.divide(kWeightScaleHidden)
 
         return bias, weight

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -19,9 +19,12 @@ class QuantizationConfig:
     nnue2score: float = 600.0
     weight_scale_hidden: float = 64.0
     weight_scale_out: float = 16.0
-    ft_quantized_one: float = 255.0
-    hidden_quantized_one: float = 127.0
-
+    ft_quantized_one: float = 256.0
+    ft_quantized_max: float = 255.0
+    hidden_quantized_one: float = 128.0
+    hidden_quantized_max: float = 127.0
+    inference_l0_division_factor: float = 512.0
+    inference_sqcrele_division_factor: float = 128.0
 
 class QuantizationManager:
     def __init__(self, config: QuantizationConfig):
@@ -31,14 +34,32 @@ class QuantizationManager:
         self.hidden_quantized_one = config.hidden_quantized_one
         self.ft_quantized_one = config.ft_quantized_one
 
-        self.max_hidden_weight = config.hidden_quantized_one / self.weight_scale_hidden
+        self.max_hidden_weight = config.hidden_quantized_one / config.weight_scale_hidden
         # Threat weights are quantized to int8 after scaling by ft_quantized_one
         _i8 = torch.iinfo(torch.int8)
-        self.min_threat_weight = _i8.min / config.ft_quantized_one  # -128/255
+        self.min_threat_weight = -_i8.max / config.ft_quantized_one  # -127/255
         self.max_threat_weight = _i8.max / config.ft_quantized_one  # 127/255
-        self.max_out_weight = (
-            config.hidden_quantized_one * self.hidden_quantized_one
-        ) / (self.nnue2score * self.weight_scale_out)
+
+        self._l0_correction_factor = config.ft_quantized_one ** 2 / config.inference_l0_division_factor / self.hidden_quantized_one
+        self._sqcrele_correction_factor = config.hidden_quantized_one / config.inference_sqcrele_division_factor
+        self._max_ft_activation = config.ft_quantized_max / config.ft_quantized_one
+        self._max_hidden_activation = config.hidden_quantized_max / config.hidden_quantized_one
+
+    @property
+    def l0_correction_factor(self):
+        return self._l0_correction_factor
+
+    @property
+    def sqcrele_correction_factor(self):
+        return self._sqcrele_correction_factor
+
+    @property
+    def max_ft_activation(self):
+        return self._max_ft_activation
+
+    @property
+    def max_hidden_activation(self):
+        return self._max_hidden_activation
 
     def generate_weight_clipping_config(
         self, model: "NNUEModel"
@@ -57,10 +78,17 @@ class QuantizationManager:
             },
             {
                 "params": [model.layer_stacks.output.linear.weight],
-                "min_weight": -self.max_out_weight,
-                "max_weight": self.max_out_weight,
+                "min_weight": -self.max_hidden_weight,
+                "max_weight": self.max_hidden_weight,
             },
         ]
+
+    def _safe_convert(self, value, target_dtype):
+        _info = torch.iinfo(target_dtype)
+        min_val = -_info.max
+        max_val = _info.max
+
+        return value.clamp(min_val, max_val).round().to(target_dtype)
 
     def quantize_feature_transformer(
         self,
@@ -97,17 +125,12 @@ class QuantizationManager:
         self,
         bias: torch.Tensor,
         weight: torch.Tensor,
-        output_layer: bool = False,
         callback: Callable = lambda *args, **kwargs: None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         kWeightScaleHidden = self.weight_scale_hidden
-        kWeightScaleOut = (
-            self.nnue2score * self.weight_scale_out / self.hidden_quantized_one
-        )
-        kWeightScale = kWeightScaleOut if output_layer else kWeightScaleHidden
-        kBiasScaleOut = self.weight_scale_out * self.nnue2score
+        kWeightScale = kWeightScaleHidden
         kBiasScaleHidden = self.weight_scale_hidden * self.hidden_quantized_one
-        kBiasScale = kBiasScaleOut if output_layer else kBiasScaleHidden
+        kBiasScale = kBiasScaleHidden
         kMaxWeight = self.hidden_quantized_one / kWeightScale
 
         bias = bias.mul(kBiasScale).round().to(torch.int32)
@@ -133,16 +156,11 @@ class QuantizationManager:
         self,
         bias: torch.Tensor,
         weight: torch.Tensor,
-        output_layer: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         kWeightScaleHidden = self.weight_scale_hidden
-        kWeightScaleOut = (
-            self.nnue2score * self.weight_scale_out / self.hidden_quantized_one
-        )
-        kWeightScale = kWeightScaleOut if output_layer else kWeightScaleHidden
-        kBiasScaleOut = self.weight_scale_out * self.nnue2score
+        kWeightScale = kWeightScaleHidden
         kBiasScaleHidden = self.weight_scale_hidden * self.hidden_quantized_one
-        kBiasScale = kBiasScaleOut if output_layer else kBiasScaleHidden
+        kBiasScale = kBiasScaleHidden
 
         bias = bias.divide(kBiasScale)
         weight = weight.divide(kWeightScale)

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -112,19 +112,27 @@ class QuantizationManager:
         f_weight_export_dtype: torch.dtype = torch.int16,
         callback: Optional[Callable] = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        psqt_weight = psqt_weight.mul(self.nnue2score * self.weight_scale_out)
-        bias = bias.mul(self.ft_quantized_one)
-        weight = weight.mul(self.ft_quantized_one)
+        if bias is not None:
+            # only weight can have different dtypes, bias is always int16, psqt_weight is always int32
+            bias = bias.mul(self.ft_quantized_one)
+            bias, bias_clipped = _safe_convert(bias, torch.int16)
 
-         # only weight can have different dtypes, bias is always int16, psqt_weight is always int32
-        bias, bias_clipped = _safe_convert(bias, torch.int16)
-        weight, weight_clipped = _safe_convert(weight, f_weight_export_dtype)
-        psqt_weight, psqt_weight_clipped = _safe_convert(psqt_weight, torch.int32)
+            if callback is not None:
+                callback("ft_bias", bias, bias_clipped)
 
-        if callback is not None:
-            callback("fct_weight", weight, weight_clipped)
-            callback("ft_bias", bias, bias_clipped)
-            callback("psqt_weight", psqt_weight, psqt_weight_clipped)
+        if weight is not None:
+            weight = weight.mul(self.ft_quantized_one)
+            weight, weight_clipped = _safe_convert(weight, f_weight_export_dtype)
+
+            if callback is not None:
+                callback("ft_weight", weight, weight_clipped)
+
+        if psqt_weight is not None:
+            psqt_weight = psqt_weight.mul(self.nnue2score * self.weight_scale_out)
+            psqt_weight, psqt_weight_clipped = _safe_convert(psqt_weight, torch.int32)
+
+            if callback is not None:
+                callback("psqt_weight", psqt_weight, psqt_weight_clipped)
 
         return bias, weight, psqt_weight
 
@@ -134,9 +142,9 @@ class QuantizationManager:
         weight: torch.Tensor,
         psqt_weight: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        bias = bias.divide(self.ft_quantized_one)
-        weight = weight.divide(self.ft_quantized_one)
-        psqt_weight = psqt_weight.divide(self.nnue2score * self.weight_scale_out)
+        bias = bias.divide(self.ft_quantized_one) if bias is not None else None
+        weight = weight.divide(self.ft_quantized_one) if weight is not None else None
+        psqt_weight = psqt_weight.divide(self.nnue2score * self.weight_scale_out) if psqt_weight is not None else None
 
         return bias, weight, psqt_weight
 

--- a/model/utils/load_model.py
+++ b/model/utils/load_model.py
@@ -10,7 +10,6 @@ def load_model(
     filename: str,
     feature_name: str,
     config: ModelConfig,
-    quantize_config: QuantizationConfig,
 ) -> NNUEModel:
     if filename.endswith(".pt"):
         model = torch.load(filename, weights_only=False)
@@ -24,7 +23,6 @@ def load_model(
             filename,
             feature_name=feature_name,
             config=config,
-            quantize_config=quantize_config,
         )
         model.eval()
         return model.model

--- a/model/utils/serialize.py
+++ b/model/utils/serialize.py
@@ -14,8 +14,12 @@ from ..model import NNUEModel
 
 
 def ascii_hist(name, x, bins=7):
-    start, end = x.min(), x.max()
+    start, end = int(x.min()), int(x.max())
+    if start >= end - bins:
+        start -= (bins + 1) // 2
+        end += bins // 2
     edges = np.linspace(start, end + 1, bins + 1).astype(int)
+    edges = np.unique(edges)
     N, X = np.histogram(x, bins=edges)
     width = 50
     nmax = N.max()

--- a/model/utils/serialize.py
+++ b/model/utils/serialize.py
@@ -59,7 +59,7 @@ def decode_leb_128_array(arr: bytes, n: int) -> npt.NDArray:
 
 
 # hardcoded for now
-VERSION = 0x7AF32F20
+VERSION = 0x6A448AFA
 DEFAULT_DESCRIPTION = "Network trained with the https://github.com/official-stockfish/nnue-pytorch trainer."
 
 
@@ -216,11 +216,10 @@ class NNUEReader:
         f: BinaryIO,
         feature_name: str,
         config: ModelConfig,
-        quantize_config: QuantizationConfig,
     ):
         self.f = f
         self.feature_name = feature_name
-        self.model = NNUEModel(feature_name, config, quantize_config)
+        self.model = NNUEModel(feature_name, config)
         self.config = config
         fc_hash = NNUEWriter.fc_hash(self.model)
 

--- a/model/utils/serialize.py
+++ b/model/utils/serialize.py
@@ -87,7 +87,7 @@ class NNUEWriter:
             self.int32(fc_hash)  # FC layers hash
             self.write_fc_layer(model, l1)
             self.write_fc_layer(model, l2)
-            self.write_fc_layer(model, output, is_output=True)
+            self.write_fc_layer(model, output)
 
     @staticmethod
     def fc_hash(model: NNUEModel) -> int:
@@ -168,7 +168,7 @@ class NNUEWriter:
         self.write_tensor(psqt_weight.flatten().numpy(), ft_compression)
 
     def write_fc_layer(
-        self, model: NNUEModel, layer: nn.Linear, is_output=False
+        self, model: NNUEModel, layer: nn.Linear
     ) -> None:
         # FC layers are stored as int8 weights, and int32 biases
         bias = layer.bias.data
@@ -191,7 +191,7 @@ class NNUEWriter:
             ascii_hist("fc weight:", weight.numpy())
 
         bias, weight = model.quantization.quantize_fc_layer(
-            bias, weight, is_output, histogram_callback
+            bias, weight, histogram_callback
         )
 
         # FC inputs are padded to 32 elements by spec.
@@ -250,7 +250,6 @@ class NNUEReader:
                 self.read_fc_layer(
                     l_w_slices[layer_idx][b],
                     l_b_slices[layer_idx][b],
-                    is_output=(layer_idx == len(layers) - 1),
                 )
 
     def read_header(self, feature_hash: int, fc_hash: int) -> None:
@@ -331,7 +330,6 @@ class NNUEReader:
         self,
         layer_weight_t: torch.Tensor,
         layer_bias_t: torch.Tensor,
-        is_output: bool = False,
     ) -> None:
         # FC inputs are padded to 32 elements by spec.
         non_padded_shape = layer_weight_t.shape
@@ -341,7 +339,7 @@ class NNUEReader:
         weight = self.tensor(np.int8, padded_shape)
 
         bias, weight = self.model.quantization.dequantize_fc_layer(
-            bias, weight, is_output
+            bias, weight
         )
 
         layer_bias = bias

--- a/model/utils/serialize.py
+++ b/model/utils/serialize.py
@@ -44,12 +44,15 @@ def get_histogram_callback(hist_title: str, verbose: bool):
             return
 
         num_clipped = int(num_clipped.sum().item())
+        min_value = values.min().item()
+        num_argmin = int((values == min_value).sum().item())
         max_value = values.max().item()
         num_argmax = int((values == max_value).sum().item())
 
         ascii_hist(f"{hist_desc}: ", values.numpy())
         print(
-            f"Layer has {num_clipped}/{total_elements} clipped weights after rounding."
+            f"Layer has {num_clipped}/{total_elements} clipped weights after rounding. "
+            f"Minimum absval in layer is {min_value}, occurring {num_argmin} times. "
             f"Maximum absval in layer is {max_value}, occurring {num_argmax} times."
         )
 

--- a/model/utils/serialize.py
+++ b/model/utils/serialize.py
@@ -24,6 +24,34 @@ def ascii_hist(name, x, bins=6):
         xi = "{0: <8.4g}".format(xi).ljust(10)
         print("{0}| {1}".format(xi, bar))
 
+def get_histogram_callback(hist_title: str, verbose: bool):
+    if not verbose:
+        return None
+
+    def histogram_callback(
+        hist_subtitle: str,
+        values: torch.Tensor,
+        num_clipped: torch.Tensor,
+    ):
+        total_elements = values.numel()
+        hist_desc = [hist_title, hist_subtitle]
+        hist_desc = " ".join(filter(None, hist_desc))
+
+        if total_elements == 0:
+            print(f"Layer '{hist_desc}' is empty.")
+            return
+
+        num_clipped = int(num_clipped.sum().item())
+        max_value = values.max().item()
+        num_argmax = int((values == max_value).sum().item())
+
+        ascii_hist(f"{hist_desc}: ", values.numpy())
+        print(
+            f"Layer has {num_clipped}/{total_elements} clipped weights after rounding."
+            f"Maximum absval in layer is {max_value}, occurring {num_argmax} times."
+        )
+
+    return histogram_callback
 
 @njit
 def encode_leb_128_array(arr: npt.NDArray) -> list:
@@ -72,21 +100,31 @@ class NNUEWriter:
         model: NNUEModel,
         description: str | None = None,
         ft_compression: str = "none",
+        verbose: bool = True,
     ):
         if description is None:
             description = DEFAULT_DESCRIPTION
 
         self.buf = bytearray()
+        self.verbose = verbose
+
+        # it is the safest to call clip weights before exporting
+        # some weights might be clipped to smaller values than dtype.max
+        # (threat weights in particular)
+        # This does change the model weights in place,
+        # since it is supposed to be called after every training step anyway, this is fine
+        model.clip_weights()
+        model.clip_input_weights()
 
         fc_hash = self.fc_hash(model)
         self.write_header(model, fc_hash, description)
         self.int32(model.feature_hash ^ (model.L1 * 2))  # Feature transformer hash
         self.write_feature_transformer(model, ft_compression)
-        for l1, l2, output in model.layer_stacks.get_coalesced_layer_stacks():
+        for bucket, (l1, l2, output) in enumerate(model.layer_stacks.get_coalesced_layer_stacks()):
             self.int32(fc_hash)  # FC layers hash
-            self.write_fc_layer(model, l1)
-            self.write_fc_layer(model, l2)
-            self.write_fc_layer(model, output)
+            self.write_fc_layer(model, l1, f"bucket {bucket} l1")
+            self.write_fc_layer(model, l2, f"bucket {bucket} l2")
+            self.write_fc_layer(model, output, f"bucket {bucket} output")
 
     @staticmethod
     def fc_hash(model: NNUEModel) -> int:
@@ -142,15 +180,8 @@ class NNUEWriter:
         weight = export_weight[:, : model.L1]
         psqt_weight = export_weight[:, model.L1 :]
 
-        def histogram_callback(
-            bias: torch.Tensor, weight: torch.Tensor, psqt_weight: torch.Tensor
-        ):
-            ascii_hist("ft bias:", bias.numpy())
-            ascii_hist("ft weight:", weight.numpy())
-            ascii_hist("ft psqt weight:", psqt_weight.numpy())
-
         bias, weight, psqt_weight = model.quantization.quantize_feature_transformer(
-            bias, weight, psqt_weight, histogram_callback
+            bias, weight, psqt_weight, get_histogram_callback("", self.verbose)
         )
 
         # Weights stored as [num_features][outputs]
@@ -167,30 +198,14 @@ class NNUEWriter:
         self.write_tensor(psqt_weight.flatten().numpy(), ft_compression)
 
     def write_fc_layer(
-        self, model: NNUEModel, layer: nn.Linear
+        self, model: NNUEModel, layer: nn.Linear, desc: str
     ) -> None:
         # FC layers are stored as int8 weights, and int32 biases
         bias = layer.bias.data
         weight = layer.weight.data
 
-        def histogram_callback(
-            bias: torch.Tensor,
-            weight: torch.Tensor,
-            clipped: torch.Tensor,
-            total_elements: int,
-            clipped_max: torch.Tensor,
-            kMaxWeight: float,
-        ):
-            ascii_hist("fc bias:", bias.numpy())
-            print(
-                "layer has {}/{} clipped weights. Exceeding by {} the maximum {}.".format(
-                    clipped, total_elements, clipped_max, kMaxWeight
-                )
-            )
-            ascii_hist("fc weight:", weight.numpy())
-
         bias, weight = model.quantization.quantize_fc_layer(
-            bias, weight, histogram_callback
+            bias, weight, get_histogram_callback(desc, self.verbose)
         )
 
         # FC inputs are padded to 32 elements by spec.

--- a/model/utils/serialize.py
+++ b/model/utils/serialize.py
@@ -127,9 +127,9 @@ class NNUEWriter:
         self.write_feature_transformer(model, ft_compression)
         for bucket, (l1, l2, output) in enumerate(model.layer_stacks.get_coalesced_layer_stacks()):
             self.int32(fc_hash)  # FC layers hash
-            self.write_fc_layer(model, l1, f"bucket {bucket} l1")
-            self.write_fc_layer(model, l2, f"bucket {bucket} l2")
-            self.write_fc_layer(model, output, f"bucket {bucket} output")
+            self.write_fc_layer(model, l1, 0, f"bucket {bucket} l1")
+            self.write_fc_layer(model, l2, 1, f"bucket {bucket} l2")
+            self.write_fc_layer(model, output, 2, f"bucket {bucket} output")
 
     @staticmethod
     def fc_hash(model: NNUEModel) -> int:
@@ -216,14 +216,18 @@ class NNUEWriter:
         self.write_tensor(psqt_weights.flatten().numpy(), ft_compression)
 
     def write_fc_layer(
-        self, model: NNUEModel, layer: nn.Linear, desc: str
+        self,
+        model: NNUEModel,
+        layer: nn.Linear,
+        layer_idx: int,
+        desc: str,
     ) -> None:
         # FC layers are stored as int8 weights, and int32 biases
         bias = layer.bias.data
         weight = layer.weight.data
 
         bias, weight = model.quantization.quantize_fc_layer(
-            bias, weight, get_histogram_callback(desc, self.verbose)
+            bias, weight, layer_idx, get_histogram_callback(desc, self.verbose)
         )
 
         # FC inputs are padded to 32 elements by spec.
@@ -282,6 +286,7 @@ class NNUEReader:
                 self.read_fc_layer(
                     l_w_slices[layer_idx][b],
                     l_b_slices[layer_idx][b],
+                    layer_idx,
                 )
 
     def read_header(self, feature_hash: int, fc_hash: int) -> None:
@@ -362,6 +367,7 @@ class NNUEReader:
         self,
         layer_weight_t: torch.Tensor,
         layer_bias_t: torch.Tensor,
+        layer_idx: int,
     ) -> None:
         # FC inputs are padded to 32 elements by spec.
         non_padded_shape = layer_weight_t.shape
@@ -371,7 +377,7 @@ class NNUEReader:
         weight = self.tensor(np.int8, padded_shape)
 
         bias, weight = self.model.quantization.dequantize_fc_layer(
-            bias, weight
+            bias, weight, layer_idx
         )
 
         layer_bias = bias

--- a/model/utils/serialize.py
+++ b/model/utils/serialize.py
@@ -185,35 +185,31 @@ class NNUEWriter:
         weight = export_weight[:, : model.L1]
         psqt_weight = export_weight[:, model.L1 :]
 
-        # Somewhat hacky approach to overcome current reading limitation in Stockfish repository
-        biases, _, psqt_weights = model.quantization.quantize_feature_transformer(
-            bias, weight, psqt_weight
+        # biases are exported as i16s
+        biases, _, _ = model.quantization.quantize_feature_transformer(
+            bias, None, None, torch.int16, get_histogram_callback("", self.verbose)
         )
 
-        # Weights stored as [num_features][outputs]
+        self.write_tensor(biases.flatten().numpy(), ft_compression)
 
+        # Weights stored as [num_features][outputs]
         offset = 0
-        weight_segments = []
         for f in layer.features:
             n = f.NUM_REAL_FEATURES
             f_export_dtype = f.EXPORT_WEIGHT_DTYPE
 
             ft_histogram_callback = get_histogram_callback(f.FEATURE_NAME, self.verbose)
-            segment_bias = bias[offset : offset + n]
             segment_weight = weight[offset : offset + n]
             segment_psqt_weight = psqt_weight[offset : offset + n]
-            _, segment_weights, _ = model.quantization.quantize_feature_transformer(
-                segment_bias, segment_weight, segment_psqt_weight, f_export_dtype, ft_histogram_callback
+            _, segment_weight, segment_psqt_weight = model.quantization.quantize_feature_transformer(
+                None, segment_weight, segment_psqt_weight, f_export_dtype, ft_histogram_callback
             )
             # threat weights are expected to always be uncompressed -- should be changed in the future
             segment_compression = ft_compression if not f_export_dtype == torch.int8 else "none"
-            weight_segments.append(tuple((segment_weights, segment_compression)))
             offset += n
 
-        self.write_tensor(biases.flatten().numpy(), ft_compression)
-        for segment_weight, segment_compression in weight_segments:
             self.write_tensor(segment_weight.flatten().numpy(), segment_compression)
-        self.write_tensor(psqt_weights.flatten().numpy(), ft_compression)
+            self.write_tensor(segment_psqt_weight.flatten().numpy(), ft_compression)
 
     def write_fc_layer(
         self,
@@ -343,14 +339,17 @@ class NNUEReader:
 
         bias = self.tensor(np.int16, [L1])
         segments = []
+        segments_psqt = []
 
         for feature in layer.features:
             dtype = np.int8 if feature.EXPORT_WEIGHT_DTYPE == torch.int8 else np.int16
             s = self.tensor(dtype, [feature.NUM_REAL_FEATURES, L1])
+            s_psqt = self.tensor(np.int32, [feature.NUM_REAL_FEATURES, num_psqt_buckets])
             segments.append(s)
+            segments_psqt.append(s_psqt)
 
         weight = torch.cat(segments, dim=0)
-        psqt_weight = self.tensor(np.int32, [num_export_features, num_psqt_buckets])
+        psqt_weight = torch.cat(segments_psqt, dim=0)
 
         bias, weight, psqt_weight = (
             self.model.quantization.dequantize_feature_transformer(

--- a/model/utils/serialize.py
+++ b/model/utils/serialize.py
@@ -333,7 +333,6 @@ class NNUEReader:
             raise Exception("Invalid compression method.")
 
     def read_feature_transformer(self, layer, num_psqt_buckets: int) -> None:
-        num_export_features = layer.NUM_REAL_FEATURES
         num_outputs = layer.num_outputs
         L1 = num_outputs - num_psqt_buckets
 

--- a/model/utils/serialize.py
+++ b/model/utils/serialize.py
@@ -13,8 +13,10 @@ from ..config import ModelConfig
 from ..model import NNUEModel
 
 
-def ascii_hist(name, x, bins=6):
-    N, X = np.histogram(x, bins=bins)
+def ascii_hist(name, x, bins=7):
+    start, end = x.min(), x.max()
+    edges = np.linspace(start, end + 1, bins + 1).astype(int)
+    N, X = np.histogram(x, bins=edges)
     width = 50
     nmax = N.max()
 
@@ -180,22 +182,35 @@ class NNUEWriter:
         weight = export_weight[:, : model.L1]
         psqt_weight = export_weight[:, model.L1 :]
 
-        bias, weight, psqt_weight = model.quantization.quantize_feature_transformer(
-            bias, weight, psqt_weight, get_histogram_callback("", self.verbose)
+        # Somewhat hacky approach to overcome current reading limitation in Stockfish repository
+        biases, _, psqt_weights = model.quantization.quantize_feature_transformer(
+            bias, weight, psqt_weight
         )
 
         # Weights stored as [num_features][outputs]
-        self.write_tensor(bias.flatten().numpy(), ft_compression)
+
         offset = 0
+        weight_segments = []
         for f in layer.features:
             n = f.NUM_REAL_FEATURES
-            segment = weight[offset : offset + n]
-            if f.EXPORT_WEIGHT_DTYPE == torch.int8:
-                self.write_tensor(segment.to(torch.int8).flatten().numpy())
-            else:
-                self.write_tensor(segment.flatten().numpy(), ft_compression)
+            f_export_dtype = f.EXPORT_WEIGHT_DTYPE
+
+            ft_histogram_callback = get_histogram_callback(f.FEATURE_NAME, self.verbose)
+            segment_bias = bias[offset : offset + n]
+            segment_weight = weight[offset : offset + n]
+            segment_psqt_weight = psqt_weight[offset : offset + n]
+            _, segment_weights, _ = model.quantization.quantize_feature_transformer(
+                segment_bias, segment_weight, segment_psqt_weight, f_export_dtype, ft_histogram_callback
+            )
+            # threat weights are expected to always be uncompressed -- should be changed in the future
+            segment_compression = ft_compression if not f_export_dtype == torch.int8 else "none"
+            weight_segments.append(tuple((segment_weights, segment_compression)))
             offset += n
-        self.write_tensor(psqt_weight.flatten().numpy(), ft_compression)
+
+        self.write_tensor(biases.flatten().numpy(), ft_compression)
+        for segment_weight, segment_compression in weight_segments:
+            self.write_tensor(segment_weight.flatten().numpy(), segment_compression)
+        self.write_tensor(psqt_weights.flatten().numpy(), ft_compression)
 
     def write_fc_layer(
         self, model: NNUEModel, layer: nn.Linear, desc: str

--- a/model/utils/serialize.py
+++ b/model/utils/serialize.py
@@ -51,8 +51,8 @@ def get_histogram_callback(hist_title: str, verbose: bool):
 
         ascii_hist(f"{hist_desc}: ", values.numpy())
         print(
-            f"Layer has {num_clipped}/{total_elements} clipped weights after rounding. "
-            f"Minimum absval in layer is {min_value}, occurring {num_argmin} times. "
+            f"Layer has {num_clipped}/{total_elements} clipped weights after rounding.\n"
+            f"Minimum absval in layer is {min_value}, occurring {num_argmin} times.\n"
             f"Maximum absval in layer is {max_value}, occurring {num_argmax} times."
         )
 

--- a/model/utils/serialize.py
+++ b/model/utils/serialize.py
@@ -11,7 +11,6 @@ from torch import nn
 
 from ..config import ModelConfig
 from ..model import NNUEModel
-from ..quantize import QuantizationConfig
 
 
 def ascii_hist(name, x, bins=6):

--- a/serialize.py
+++ b/serialize.py
@@ -79,7 +79,6 @@ def main():
         nnue = M.NNUE.load_from_checkpoint(
             args.source,
             config=nnue_lightning_config,
-            quantize_config=M.QuantizationConfig(),
             map_location=torch.device("cpu"),
         )
         nnue.eval()
@@ -89,13 +88,11 @@ def main():
         with open(args.source, "rb") as f:
             nnue = M.NNUE(
                 config=nnue_lightning_config,
-                quantize_config=M.QuantizationConfig(),
             )
             reader = M.NNUEReader(
                 f,
                 feature_name,
                 config=nnue_lightning_config.model_config,
-                quantize_config=M.QuantizationConfig(),
             )
             nnue.model = reader.model
             if serialize_config.description is None:

--- a/train.py
+++ b/train.py
@@ -328,7 +328,6 @@ def main():
             max_epoch=max_epoch,
             num_batches_per_epoch=args.num_batches_per_epoch,
             param_index=args.dataloader_config.param_index,
-            quantize_config=M.QuantizationConfig(),
         )
     else:
         assert os.path.exists(args.resume_from_model)

--- a/visualize.py
+++ b/visualize.py
@@ -664,7 +664,6 @@ def main():
         args.model,
         feature_name,
         M.ModelConfig.get_model_config(args),
-        M.QuantizationConfig(),
     )
 
     if args.ref_model:
@@ -674,7 +673,6 @@ def main():
             args.ref_model,
             ref_feature_name,
             M.ModelConfig.get_model_config(args),
-            M.QuantizationConfig(),
         )
 
         print(

--- a/visualize_multi_hist.py
+++ b/visualize_multi_hist.py
@@ -88,7 +88,6 @@ def main():
             m,
             feature_name,
             config,
-            M.QuantizationConfig(),
         )
         for m in args.models
     ]


### PR DESCRIPTION
Improves quant config and removes hard coded values from the code.

The main goal is to improve readability and maintainability. As of currently there is a mismatch between training and inference (see #416 for more information). This patch intends to not only fix the mismatch but also to prevent mismatches in the future by inferring runtime correction factors directly from the quantization config instead of relying on manual changes across the codebase.

This allows arbitrary changes to the weight and activation quantization scales without having to make changes across the entire codebase.

As a quality of life improvement, serialize.py and quantize.py were refactored and the information density of the histogram callback was improved: The current histogram callback reports three values that are rather uninformative, since the model weights are already clipped through the callbacks. The logic was changed to use the native clipping of the model first and then clip only for type safety for serialization.

Changes quant scheme slightly (Test code at https://github.com/TonyCongqianWang/Stockfish/tree/gruenerapfel/quant_fix).

In particular ft_one = 256 and  hidden_one=128 for clean power of two scales -- which is the standard for fixed scale qat.

Output scale is handled by https://github.com/TonyCongqianWang/Stockfish/blob/384175653285f68b67bd6a8d696380c40731e8c8/src/nnue/nnue_architecture.h#L135 which should yield slightly higher resolution. The main advantage however is better maintainability.

The maximum number of fully saturated inputs to i32 with i8*i8 inputs would be `133,144 / (600 * OutputScale) = 13` There is actually some risk of overflow even with the current setup, as even L3 has enough neurons and L1 has a skip connection. However given that L1=8k worked, this should be fine. But as a safety measure I will change the order of operation so that the maximum number of fully saturated neurons becomes `133,144 / (600 * OutputScale / WeightScale) = 887`