### PR TITLE
add flag to skip affinity

### DIFF
--- a/ddp_launcher.py
+++ b/ddp_launcher.py
@@ -22,13 +22,16 @@ def main():
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("--num-workers", dest="num_workers", type=int, default=0)
     parser.add_argument("--threads", type=int, default=-1)
+    parser.add_argument("--no-affinity", action="store_true")
 
     # args contains our intercepted values; unknown_args contains everything else
     args, unknown_args = parser.parse_known_args(train_args)
 
     # 3. Apply constraints and get the optimal bounds
     actual_threads, actual_workers = setup_environment(
-        requested_threads=args.threads, requested_workers=args.num_workers
+        requested_threads=args.threads,
+        requested_workers=args.num_workers,
+        bind_affinity=not args.no_affinity,
     )
 
     # 4. Reconstruct the command line for the target script
@@ -44,6 +47,7 @@ def main():
             f"[Launcher] Intercepted requests: threads={args.threads}, workers={args.num_workers}",
             flush=True,
         )
+        print(f"[Launcher] Affinity binding   : {not args.no_affinity}", flush=True)
         print(
             f"[Launcher] Applied constraints : threads={actual_threads}, workers={actual_workers}",
             flush=True,

--- a/ddp_utils/ddp_init.py
+++ b/ddp_utils/ddp_init.py
@@ -243,12 +243,21 @@ def enforce_gpu_numa_affinity():
         return _get_fallback_core_count("Failed to set CPU affinity: " + str(e))
 
 
-def setup_environment(requested_threads: int = -1, requested_workers: int = 0):
+def setup_environment(
+    requested_threads: int = -1,
+    requested_workers: int = 0,
+    bind_affinity: bool = True,
+):
     """
     Applies OS constraints before heavy library loading.
     """
     os.environ["PYTHONUNBUFFERED"] = "1"
-    available_cores = enforce_gpu_numa_affinity()
+    if bind_affinity:
+        available_cores = enforce_gpu_numa_affinity()
+    else:
+        available_cores = _get_fallback_core_count(
+            "Affinity binding disabled by user request"
+        )
 
     usable_cores = max(1, available_cores - 1)
     if requested_threads < 0:


### PR DESCRIPTION
not everyone benefits from multi gpu, so sometimes it's beneficial to use both gpus for different training runs, in which case affinity needs to be disabled