### PR TITLE
[WIP] Quantization Refactor

### DIFF
--- a/.github/workflows/cpu-testrun.yml
+++ b/.github/workflows/cpu-testrun.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-bench:
+  train-and-cross-check:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:

--- a/cross_check_eval.py
+++ b/cross_check_eval.py
@@ -186,14 +186,12 @@ def main():
             args.checkpoint,
             feature_name=feature_name,
             config=ModelConfig.get_model_config(args),
-            quantize_config=QuantizationConfig(),
         )
     else:
         model = read_model(
             args.net,
             feature_name,
             ModelConfig.get_model_config(args),
-            QuantizationConfig(),
         )
     model.eval()
     input_feature_name = model.model.input_feature_name

--- a/cross_check_eval.py
+++ b/cross_check_eval.py
@@ -62,7 +62,7 @@ def make_fen_batch_provider(data_path, batch_size):
     )
 
 
-def eval_model_batch(model, batch: data_loader.SparseBatchPtr, device: str):
+def eval_model_batch(model: M.NNUEModel, batch: data_loader.SparseBatchPtr, device: str):
     (
         us,
         them,
@@ -87,6 +87,7 @@ def eval_model_batch(model, batch: data_loader.SparseBatchPtr, device: str):
             black_values,
             psqt_indices,
             layer_stack_indices,
+            fake_quantize_acts=True,
         )
         * model.quantization.nnue2score
     ]

--- a/cross_check_eval.py
+++ b/cross_check_eval.py
@@ -44,10 +44,9 @@ class CliConfig:
 def read_model(
     nnue_path,
     config: M.NNUELightningConfig,
-    quantize_config: M.QuantizationConfig,
 ):
     with open(nnue_path, "rb") as f:
-        reader = M.NNUEReader(f, config.features, config.model_config, quantize_config)
+        reader = M.NNUEReader(f, config.features, config.model_config)
         return reader.model
 
 
@@ -292,13 +291,11 @@ def main():
         model = M.NNUE.load_from_checkpoint(
             cross_check_config.checkpoint,
             config=nnue_lightning_config,
-            quantize_config=M.QuantizationConfig(),
         )
     else:
         model = read_model(
             cross_check_config.net,
             config=nnue_lightning_config,
-            quantize_config=M.QuantizationConfig(),
         )
     model.to(cross_check_config.device)
     model.eval()

--- a/cross_check_eval.py
+++ b/cross_check_eval.py
@@ -10,7 +10,6 @@ from model import (
     NNUE,
     NNUEReader,
     ModelConfig,
-    QuantizationConfig,
 )
 
 
@@ -18,10 +17,9 @@ def read_model(
     nnue_path,
     feature_name: str,
     config: ModelConfig,
-    quantize_config: QuantizationConfig,
 ):
     with open(nnue_path, "rb") as f:
-        reader = NNUEReader(f, feature_name, config, quantize_config)
+        reader = NNUEReader(f, feature_name, config)
         return reader.model
 
 

--- a/ftperm.py
+++ b/ftperm.py
@@ -561,7 +561,7 @@ def eval_ft(model: NNUEModel, batch: data_loader.SparseBatchPtr, device_str: str
             psqt_indices,
             layer_stack_indices,
         ) = batch_tuple
-        res = model.forward_ft(
+        l0_, wpsqt, bpsqt = model.forward_ft(
             us,
             them,
             white_indices,
@@ -571,7 +571,8 @@ def eval_ft(model: NNUEModel, batch: data_loader.SparseBatchPtr, device_str: str
             psqt_indices,
             fake_quantize_acts=True,
         )
-        return res
+        _, _ = wpsqt, bpsqt
+        return l0_
 
 
 def ft_permute_impl(model: NNUEModel, perm: npt.NDArray[np.int_]) -> None:

--- a/ftperm.py
+++ b/ftperm.py
@@ -536,14 +536,6 @@ def make_sparse_batch_provider(
     )
 
 
-def quantize_ft(model: NNUEModel) -> None:
-    for f in model.input.features:
-        f.weight.data = f.weight.data.mul(model.quantization.ft_quantized_one).round()
-    model.input.bias.data = model.input.bias.data.mul(
-        model.quantization.ft_quantized_one
-    ).round()
-
-
 def eval_ft(model: NNUEModel, batch: data_loader.SparseBatchPtr, device_str: str) -> torch.Tensor:
     with torch.no_grad():
         batch_tuple = tuple(
@@ -617,14 +609,12 @@ def gather_impl(
     ZERO_POINT = 0.0  # Vary this to check hypothetical forced larger truncation to zero
     BATCH_SIZE = 1024
 
-    quantized_model = copy.deepcopy(model)
-    quantize_ft(quantized_model)
-    quantized_model.to(device_str)
+    model = model.to(device_str)
 
     sparse_batch_provider = make_sparse_batch_provider(
         dataset,
         BATCH_SIZE,
-        quantized_model.input_feature_name,
+        model.input_feature_name,
         loader_num_workers=loader_workers,
         loader_config=loader_config
     )
@@ -637,7 +627,7 @@ def gather_impl(
         # checks are already filtered by sparse_batch_provider.
         s_batch = next(sparse_batch_provider)
 
-        actmat = eval_ft(quantized_model, s_batch, device_str).cpu()
+        actmat = eval_ft(model, s_batch, device_str).cpu()
         actmat = actmat <= ZERO_POINT
         actmat = actmat.numpy()
         actmats.append(actmat)

--- a/ftperm.py
+++ b/ftperm.py
@@ -511,7 +511,7 @@ def read_model(
     config: M.ModelConfig,
 ) -> NNUEModel:
     with open(nnue_path, "rb") as f:
-        reader = NNUEReader(f, feature_name, config, quantize_config)
+        reader = NNUEReader(f, feature_name, config)
         return reader.model
 
 

--- a/ftperm.py
+++ b/ftperm.py
@@ -538,9 +538,8 @@ def make_sparse_batch_provider(
 def quantize_ft(model: NNUEModel) -> None:
     for f in model.input.features:
         f.weight.data = f.weight.data.mul(model.quantization.ft_quantized_one).round()
-    model.input.bias.data = model.input.bias.data.mul(
-        model.quantization.ft_quantized_one
-    ).round()
+        f.weight.data = f.weight.data.div_(model.quantization.ft_quantized_one)
+    model.input.bias.data = model.input.bias.data.mul(model.quantization.ft_quantized_one).round()
     model.input.bias.data.div_(model.quantization.ft_quantized_one)
 
 

--- a/ftperm.py
+++ b/ftperm.py
@@ -544,36 +544,9 @@ def quantize_ft(model: NNUEModel) -> None:
     ).round()
 
 
-def forward_ft(
-    model: NNUEModel,
-    us: torch.Tensor,
-    them: torch.Tensor,
-    white_indices: torch.Tensor,
-    white_values: torch.Tensor,
-    black_indices: torch.Tensor,
-    black_values: torch.Tensor,
-    psqt_indices: torch.Tensor,
-    layer_stack_indices: torch.Tensor,
-) -> torch.Tensor:
-    wp, bp = model.input(white_indices, white_values, black_indices, black_values)
-    w, _ = torch.split(wp, model.L1, dim=1)
-    b, _ = torch.split(bp, model.L1, dim=1)
-    l0_ = (us * torch.cat([w, b], dim=1)) + (them * torch.cat([b, w], dim=1))
-    l0_ = torch.clamp(l0_, 0.0, model.quantization.ft_quantized_one)
-
-    l0_s = torch.split(l0_, model.L1 // 2, dim=1)
-    l0_s1 = [l0_s[0] * l0_s[1], l0_s[2] * l0_s[3]]
-    # We multiply by 255/512 because in the quantized network 1.0 is represented by 255
-    # and we want to scale to 1.0=127, but a shift is faster than a division (in inference)
-    l0_ = torch.cat(l0_s1, dim=1) * (1 / 512)
-
-    # Inference uses bitshift which is equivalent to rounding down (floor).
-    return l0_.floor()
-
-
 def eval_ft(model: NNUEModel, batch: data_loader.SparseBatchPtr, device_str: str) -> torch.Tensor:
     with torch.no_grad():
-        batch = tuple(
+        batch_tuple = tuple(
             batch_part.to(device=device_str) for batch_part in batch
         )
         (
@@ -587,9 +560,8 @@ def eval_ft(model: NNUEModel, batch: data_loader.SparseBatchPtr, device_str: str
             score,
             psqt_indices,
             layer_stack_indices,
-        ) = batch
-        res = forward_ft(
-            model,
+        ) = batch_tuple
+        res = model.forward_ft(
             us,
             them,
             white_indices,
@@ -597,7 +569,7 @@ def eval_ft(model: NNUEModel, batch: data_loader.SparseBatchPtr, device_str: str
             black_indices,
             black_values,
             psqt_indices,
-            layer_stack_indices,
+            fake_quantize_acts=True,
         )
         return res
 

--- a/ftperm.py
+++ b/ftperm.py
@@ -676,7 +676,6 @@ def command_gather(args: FeaturePermutationConfig) -> None:
             args.subcommand.checkpoint,
             feature_name=args.feature_config.features,
             config=args.model_config,
-            quantize_config=QuantizationConfig(),
         )
         model = nnue.model
     else:
@@ -685,7 +684,6 @@ def command_gather(args: FeaturePermutationConfig) -> None:
             args.subcommand.net,
             args.feature_config.features,
             args.model_config,
-            QuantizationConfig(),
         )
 
     model.eval()

--- a/ftperm.py
+++ b/ftperm.py
@@ -535,6 +535,14 @@ def make_sparse_batch_provider(
         config=loader_config,
     )
 
+def quantize_ft(model: NNUEModel) -> None:
+    for f in model.input.features:
+        f.weight.data = f.weight.data.mul(model.quantization.ft_quantized_one).round()
+    model.input.bias.data = model.input.bias.data.mul(
+        model.quantization.ft_quantized_one
+    ).round()
+    model.input.bias.data.div_(model.quantization.ft_quantized_one)
+
 
 def eval_ft(model: NNUEModel, batch: data_loader.SparseBatchPtr, device_str: str) -> torch.Tensor:
     with torch.no_grad():
@@ -609,12 +617,13 @@ def gather_impl(
     ZERO_POINT = 0.0  # Vary this to check hypothetical forced larger truncation to zero
     BATCH_SIZE = 1024
 
-    model = copy.deepcopy(model).to(device_str)
+    weight_quantized_model = copy.deepcopy(model).to(device_str)
+    quantize_ft(weight_quantized_model)
 
     sparse_batch_provider = make_sparse_batch_provider(
         dataset,
         BATCH_SIZE,
-        model.input_feature_name,
+        weight_quantized_model.input_feature_name,
         loader_num_workers=loader_workers,
         loader_config=loader_config
     )
@@ -627,7 +636,7 @@ def gather_impl(
         # checks are already filtered by sparse_batch_provider.
         s_batch = next(sparse_batch_provider)
 
-        actmat = eval_ft(model, s_batch, device_str).cpu()
+        actmat = eval_ft(weight_quantized_model, s_batch, device_str).cpu()
         actmat = actmat <= ZERO_POINT
         actmat = actmat.numpy()
         actmats.append(actmat)

--- a/ftperm.py
+++ b/ftperm.py
@@ -609,7 +609,7 @@ def gather_impl(
     ZERO_POINT = 0.0  # Vary this to check hypothetical forced larger truncation to zero
     BATCH_SIZE = 1024
 
-    model = model.to(device_str)
+    model = copy.deepcopy(model).to(device_str)
 
     sparse_batch_provider = make_sparse_batch_provider(
         dataset,

--- a/ftperm.py
+++ b/ftperm.py
@@ -54,7 +54,6 @@ from model import (
     NNUE,
     NNUEModel,
     NNUEReader,
-    QuantizationConfig,
     FeatureConfig,
     ModelConfig,
 )
@@ -510,7 +509,6 @@ def read_model(
     nnue_path: str,
     feature_name: str,
     config: M.ModelConfig,
-    quantize_config: QuantizationConfig,
 ) -> NNUEModel:
     with open(nnue_path, "rb") as f:
         reader = NNUEReader(f, feature_name, config, quantize_config)

--- a/ftperm.py
+++ b/ftperm.py
@@ -52,7 +52,6 @@ from model import (
     NNUE,
     NNUEModel,
     NNUEReader,
-    QuantizationConfig,
     FeatureConfig,
     ModelConfig,
 )
@@ -498,10 +497,9 @@ def read_model(
     nnue_path: str,
     feature_name: str,
     config: M.ModelConfig,
-    quantize_config: QuantizationConfig,
 ) -> NNUEModel:
     with open(nnue_path, "rb") as f:
-        reader = NNUEReader(f, feature_name, config, quantize_config)
+        reader = NNUEReader(f, feature_name, config)
         return reader.model
 
 
@@ -686,7 +684,6 @@ def command_gather(args: FeaturePermutationConfig) -> None:
             config=M.NNUELightningConfig(
                 model_config=args.model_config,
             ),
-            quantize_config=QuantizationConfig(),
             map_location=torch.device("cpu"),
         )
         model = nnue.model
@@ -696,7 +693,6 @@ def command_gather(args: FeaturePermutationConfig) -> None:
             args.subcommand.net,
             args.subcommand.feature_config.features,
             args.model_config,
-            QuantizationConfig(),
         )
 
     model.eval()

--- a/model/callbacks.py
+++ b/model/callbacks.py
@@ -9,18 +9,36 @@ from .lightning_module import NNUE
 
 
 class WeightClippingCallback(L.Callback):
-    def on_train_batch_start(
+    @torch.no_grad()
+    @torch.compiler.disable
+    def on_train_batch_end(
         self,
         trainer: L.Trainer,
         pl_module: L.LightningModule,
+        outputs,
         batch,
         batch_idx: int,
     ) -> None:
         _, _ = trainer, batch  # Unused
         assert isinstance(pl_module, NNUE)
         pl_module.model.clip_weights()
-        if batch_idx == 0:
-            pl_module.model.clip_input_weights()
+
+    @torch.no_grad()
+    @torch.compiler.disable
+    def on_train_epoch_end(self, trainer, pl_module):
+        _ = trainer # Unused
+        assert isinstance(pl_module, NNUE)
+        pl_module.model.clip_weights()
+        pl_module.model.clip_input_weights()
+
+    @torch.no_grad()
+    @torch.compiler.disable
+    def on_save_checkpoint(self, trainer, pl_module, checkpoint):
+        _, _ = trainer, checkpoint  # Unused
+        assert isinstance(pl_module, NNUE)
+        pl_module.model.clip_weights()
+        pl_module.model.clip_input_weights()
+
 
 class ExplicitSWACallback(L.Callback):
     def __init__(self, swa_start_epoch: int, save_dir: str):
@@ -39,12 +57,14 @@ class ExplicitSWACallback(L.Callback):
             self.swa_model.module.load_state_dict(tmp)
             self.to_eval = not self.to_eval
 
+    @torch.no_grad()
     @torch.compiler.disable
     def on_train_start(self, trainer, pl_module):
         if not trainer.is_global_zero:
             return
         self.swa_model = AveragedModel(pl_module.model)
 
+    @torch.no_grad()
     @torch.compiler.disable
     def on_train_epoch_end(self, trainer, pl_module):
         if not trainer.is_global_zero or trainer.current_epoch < self.swa_start_epoch:
@@ -53,6 +73,8 @@ class ExplicitSWACallback(L.Callback):
         self.swa_model.update_parameters(pl_module.model)
         pl_module.train()
 
+    @torch.no_grad()
+    @torch.compiler.disable
     def state_dict(self):
         # Prevent Lightning from saving the SWA callback's internal state
         # in the regular epoch checkpoints, avoiding redundant memory bloat.
@@ -60,9 +82,13 @@ class ExplicitSWACallback(L.Callback):
         # but that's an acceptable tradeoff for now.
         return {}
 
+    @torch.no_grad()
+    @torch.compiler.disable
     def load_state_dict(self, state_dict):
         _ = state_dict # Unused
 
+    @torch.no_grad()
+    @torch.compiler.disable
     def on_save_checkpoint(self, trainer, pl_module, checkpoint):
         _ = pl_module  # Unused
         if trainer.current_epoch >= self.swa_start_epoch:
@@ -75,6 +101,8 @@ class ExplicitSWACallback(L.Callback):
             if trainer.is_global_zero:
                 print(f"[ExplicitSWACallback] Stripping optimizer and lr_scheduler states from checkpoint at epoch {trainer.current_epoch} to save memory.")
 
+    @torch.no_grad()
+    @torch.compiler.disable
     def on_load_checkpoint(self, trainer, pl_module, checkpoint):
         _, _ = trainer, pl_module  # Unused
         checkpoint_epoch = checkpoint.get("epoch")
@@ -87,6 +115,8 @@ class ExplicitSWACallback(L.Callback):
                 f"Checkpoint epoch {checkpoint_epoch} > SWA start epoch {self.swa_start_epoch}"
             )
 
+    @torch.no_grad()
+    @torch.compiler.disable
     def on_train_end(self, trainer, pl_module):
         if trainer.current_epoch < self.swa_start_epoch:
             return

--- a/model/callbacks.py
+++ b/model/callbacks.py
@@ -21,23 +21,21 @@ class WeightClippingCallback(L.Callback):
     ) -> None:
         _, _ = trainer, batch  # Unused
         assert isinstance(pl_module, NNUE)
-        pl_module.model.clip_weights()
+        pl_module.model.clip_weights(include_input=False)
 
     @torch.no_grad()
     @torch.compiler.disable
     def on_train_epoch_end(self, trainer, pl_module):
         _ = trainer # Unused
         assert isinstance(pl_module, NNUE)
-        pl_module.model.clip_weights()
-        pl_module.model.clip_input_weights()
+        pl_module.model.clip_weights(include_input=True)
 
     @torch.no_grad()
     @torch.compiler.disable
     def on_save_checkpoint(self, trainer, pl_module, checkpoint):
         _, _ = trainer, checkpoint  # Unused
         assert isinstance(pl_module, NNUE)
-        pl_module.model.clip_weights()
-        pl_module.model.clip_input_weights()
+        pl_module.model.clip_weights(include_input=True)
 
 
 class ExplicitSWACallback(L.Callback):

--- a/model/config.py
+++ b/model/config.py
@@ -4,6 +4,7 @@ from typing import Annotated
 import tyro
 from tyro.conf import OmitArgPrefixes
 
+from .quantize import QuantizationConfig
 from .optimizers import OptimizerConfig
 from .modules import FeatureConfig, LayerStacksConfig
 
@@ -32,6 +33,9 @@ class ModelConfig(LayerStacksConfig):
         config.L1 = args.L1
         config.L2 = args.L2
         return config
+
+    # Not omitting prefix on purpose.
+    quantize_config: QuantizationConfig = field(default_factory=QuantizationConfig)
 
 
 # parameters needed for the definition of the loss

--- a/model/config.py
+++ b/model/config.py
@@ -87,6 +87,9 @@ class LossParams:
 
 @dataclass(kw_only=True)
 class NNUELightningConfig(FeatureConfig):
+    use_fake_quantization: bool = True
+    """Wether to use fake quantization with STE during training."""
+
     model_config: OmitArgPrefixes[ModelConfig] = field(default_factory=ModelConfig)
     loss_params: OmitArgPrefixes[LossParams] = field(default_factory=LossParams)
     optimizer_config: OmitArgPrefixes[OptimizerConfig] = field(

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -247,6 +247,7 @@ class NNUE(L.LightningModule):
                 black_values,
                 psqt_indices,
                 layer_stack_indices,
+                self.config.use_fake_quantization,
             )
         )
 

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -6,7 +6,6 @@ from torchmetrics import MeanMetric, MetricCollection
 
 from .config import NNUELightningConfig
 from .model import NNUEModel
-from .quantize import QuantizationConfig
 from .lambda_utils import LambdaController
 
 
@@ -53,7 +52,6 @@ class NNUE(L.LightningModule):
         config: NNUELightningConfig,
         max_epoch=None,
         num_batches_per_epoch=None,
-        quantize_config=QuantizationConfig(),
         param_index=0,
         num_psqt_buckets=8,
         num_ls_buckets=8,
@@ -63,7 +61,6 @@ class NNUE(L.LightningModule):
         self.model: NNUEModel = NNUEModel(
             config.features,
             config.model_config,
-            quantize_config,
             num_psqt_buckets,
             num_ls_buckets,
         )

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -5,7 +5,6 @@ from torchmetrics import MeanMetric, MetricCollection
 
 from .config import NNUELightningConfig
 from .model import NNUEModel
-from .quantize import QuantizationConfig
 
 
 def _get_parameters(layers: list[nn.Module], get_biases: bool = False):
@@ -29,7 +28,6 @@ class NNUE(L.LightningModule):
         config: NNUELightningConfig,
         max_epoch=None,
         num_batches_per_epoch=None,
-        quantize_config=QuantizationConfig(),
         param_index=0,
         num_psqt_buckets=8,
         num_ls_buckets=8,
@@ -39,7 +37,6 @@ class NNUE(L.LightningModule):
         self.model: NNUEModel = NNUEModel(
             config.features,
             config.model_config,
-            quantize_config,
             num_psqt_buckets,
             num_ls_buckets,
         )

--- a/model/model.py
+++ b/model/model.py
@@ -79,7 +79,7 @@ class NNUEModel(nn.Module):
         black_values: torch.Tensor,
         psqt_indices: torch.Tensor,
         fake_quantize_acts: bool=False,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
        # NOTE possibly refactor this into own class. Fused kernel would be beneficial for speed.
         wp, bp = self.input(white_indices, white_values, black_indices, black_values)
         w, wpsqt = torch.split(wp, self.L1, dim=1)

--- a/model/model.py
+++ b/model/model.py
@@ -66,8 +66,10 @@ class NNUEModel(nn.Module):
                             )
                     p_data_fp32.clamp_(min_weight, max_weight)
 
+
     def clip_input_weights(self):
         self.input.clip_weights(self.quantization)
+
 
     def forward_ft(
         self,

--- a/model/model.py
+++ b/model/model.py
@@ -106,7 +106,7 @@ class NNUEModel(nn.Module):
             # so it should be `fake_quantize_ls_act`
             # TODO: Find out why
             # `fake_quantize_ft_act` leads to a lower cross_eval error....
-            l0_ = self.quantization.fake_quantize_ls_act(l0_)
+            l0_ = self.quantization.fake_quantize_ft_act(l0_)
 
 
         return l0_, wpsqt, bpsqt

--- a/model/model.py
+++ b/model/model.py
@@ -98,6 +98,7 @@ class NNUEModel(nn.Module):
         l0_s = torch.split(l0_, self.L1 // 2, dim=1)
         l0_s1 = [l0_s[0] * l0_s[1], l0_s[2] * l0_s[3]]
         l0_ = torch.cat(l0_s1, dim=1)
+
         # We multiply by a correction factor, so we can use only bitshift and multiplication at inference.
         l0_ = l0_ * self.quantization.l0_correction_factor
 
@@ -107,6 +108,7 @@ class NNUEModel(nn.Module):
             # TODO: Find out why
             # `fake_quantize_ft_act` leads to a lower cross_eval error....
             l0_ = self.quantization.fake_quantize_ls_act(l0_)
+
 
         return l0_, wpsqt, bpsqt
 

--- a/model/model.py
+++ b/model/model.py
@@ -96,6 +96,8 @@ class NNUEModel(nn.Module):
 
         l0_s = torch.split(l0_, self.L1 // 2, dim=1)
         l0_s1 = [l0_s[0] * l0_s[1], l0_s[2] * l0_s[3]]
+        if fake_quantize_acts:
+            l0_s1 = self.quantization.fake_quantize_ft_act(l0_s1)
         # We multiply by a correction factor, so we can use only bitshift and multiplication at inference.
         l0_ = torch.cat(l0_s1, dim=1) * self.quantization.l0_correction_factor
 

--- a/model/model.py
+++ b/model/model.py
@@ -91,7 +91,7 @@ class NNUEModel(nn.Module):
 
         l0_ = (us * torch.cat([w, b], dim=1)) + (them * torch.cat([b, w], dim=1))
         if fake_quantize_acts:
-            l0_ = self.quantization.fake_quantize_ft_act(l0_)
+            pass # do not fake quantize sum of (quantitized) weights
         l0_ = self.quantization.clip_ft_act(l0_)
 
         l0_s = torch.split(l0_, self.L1 // 2, dim=1)

--- a/model/model.py
+++ b/model/model.py
@@ -99,15 +99,13 @@ class NNUEModel(nn.Module):
         l0_s1 = [l0_s[0] * l0_s[1], l0_s[2] * l0_s[3]]
         l0_ = torch.cat(l0_s1, dim=1)
 
-        # We multiply by a correction factor, so we can use only bitshift and multiplication at inference.
-        l0_ = l0_ * self.quantization.l0_correction_factor
         if fake_quantize_acts:
-            # after Hadamard product act_scale is converted
-            # so it should be `fake_quantize_ls_act`
-            # TODO: Find out why
-            # `fake_quantize_ft_act` leads to a lower cross_eval error....
             l0_ = self.quantization.fake_quantize_ft_act(l0_)
-
+        # We multiply by a correction factor,
+        # so we can use only bitshift and multiplication at inference.
+        # When using fake quantization any correction factor
+        # not equal 1.0 will lead to diverging discrete grids
+        l0_ = l0_ * self.quantization.l0_correction_factor
 
         return l0_, wpsqt, bpsqt
 

--- a/model/model.py
+++ b/model/model.py
@@ -69,6 +69,46 @@ class NNUEModel(nn.Module):
     def clip_input_weights(self):
         self.input.clip_weights(self.quantization)
 
+    def forward_ft(
+        self,
+        us: torch.Tensor,
+        them: torch.Tensor,
+        white_indices: torch.Tensor,
+        white_values: torch.Tensor,
+        black_indices: torch.Tensor,
+        black_values: torch.Tensor,
+        psqt_indices: torch.Tensor,
+        fake_quantize_acts: bool=False,
+    ) -> torch.Tensor:
+       # NOTE possibly refactor this into own class. Fused kernel would be beneficial for speed.
+        wp, bp = self.input(white_indices, white_values, black_indices, black_values)
+        w, wpsqt = torch.split(wp, self.L1, dim=1)
+        b, bpsqt = torch.split(bp, self.L1, dim=1)
+
+        psqt_indices_unsq = psqt_indices.unsqueeze(dim=1)
+        wpsqt = wpsqt.gather(1, psqt_indices_unsq)
+        bpsqt = bpsqt.gather(1, psqt_indices_unsq)
+
+        l0_ = (us * torch.cat([w, b], dim=1)) + (them * torch.cat([b, w], dim=1))
+        l0_ = torch.clamp(l0_, 0.0, self.quantization.max_ft_activation)
+        if fake_quantize_acts:
+            # Fake quantization with STE
+            # NOTE if we use fake quantization in more spots,
+            # we should refactor this into its own class
+            # Inference uses bitshift which is equivalent to rounding down (floor).
+            act_scale = self.quantization.config.inference_l0_division_factor
+            l0_hard = ((l0_ * act_scale).floor() / act_scale).detach()
+            l0_soft = l0_.detach()
+            l0_ = l0_hard + (l0_ - l0_soft)
+
+        l0_s = torch.split(l0_, self.L1 // 2, dim=1)
+        l0_s1 = [l0_s[0] * l0_s[1], l0_s[2] * l0_s[3]]
+        # We multiply by a correction factor, so we can use only bitshift and multiplication at inference.
+        l0_ = torch.cat(l0_s1, dim=1) * self.quantization.l0_correction_factor
+
+        return l0_, wpsqt, bpsqt
+
+
     def forward(
         self,
         us: torch.Tensor,
@@ -79,21 +119,18 @@ class NNUEModel(nn.Module):
         black_values: torch.Tensor,
         psqt_indices: torch.Tensor,
         layer_stack_indices: torch.Tensor,
+        fake_quantize_acts: bool=False,
     ):
-        wp, bp = self.input(white_indices, white_values, black_indices, black_values)
-        w, wpsqt = torch.split(wp, self.L1, dim=1)
-        b, bpsqt = torch.split(bp, self.L1, dim=1)
-        l0_ = (us * torch.cat([w, b], dim=1)) + (them * torch.cat([b, w], dim=1))
-        l0_ = torch.clamp(l0_, 0.0, self.quantization.max_ft_activation)
-
-        l0_s = torch.split(l0_, self.L1 // 2, dim=1)
-        l0_s1 = [l0_s[0] * l0_s[1], l0_s[2] * l0_s[3]]
-        # We multiply by a correction factor, so we can use only bitshift and multiplication at inference.
-        l0_ = torch.cat(l0_s1, dim=1) * self.quantization.l0_correction_factor
-
-        psqt_indices_unsq = psqt_indices.unsqueeze(dim=1)
-        wpsqt = wpsqt.gather(1, psqt_indices_unsq)
-        bpsqt = bpsqt.gather(1, psqt_indices_unsq)
+        l0_, wpsqt, bpsqt = self.forward_ft(
+            us,
+            them,
+            white_indices,
+            white_values,
+            black_indices,
+            black_values,
+            psqt_indices,
+            fake_quantize_acts,
+        )
         # The PSQT values are averaged over perspectives. "Their" perspective
         # has a negative influence (us-0.5 is 0.5 for white and -0.5 for black,
         # which does both the averaging and sign flip for black to move)

--- a/model/model.py
+++ b/model/model.py
@@ -101,7 +101,8 @@ class NNUEModel(nn.Module):
         l0_ = l0_ * self.quantization.l0_correction_factor
 
         if fake_quantize_acts:
-            l0_ = self.quantization.fake_quantize_ft_act(l0_)
+            # after Hadamard product act_scale is converted
+            l0_ = self.quantization.fake_quantize_ls_act(l0_)
 
         return l0_, wpsqt, bpsqt
 

--- a/model/model.py
+++ b/model/model.py
@@ -106,7 +106,7 @@ class NNUEModel(nn.Module):
             # so it should be `fake_quantize_ls_act`
             # TODO: Find out why
             # `fake_quantize_ft_act` leads to a lower cross_eval error....
-            l0_ = self.quantization.fake_quantize_ft_act(l0_)
+            l0_ = self.quantization.fake_quantize_ls_act(l0_)
 
 
         return l0_, wpsqt, bpsqt

--- a/model/model.py
+++ b/model/model.py
@@ -96,10 +96,12 @@ class NNUEModel(nn.Module):
 
         l0_s = torch.split(l0_, self.L1 // 2, dim=1)
         l0_s1 = [l0_s[0] * l0_s[1], l0_s[2] * l0_s[3]]
-        if fake_quantize_acts:
-            l0_s1 = self.quantization.fake_quantize_ft_act(l0_s1)
+        l0_ = torch.cat(l0_s1, dim=1)
         # We multiply by a correction factor, so we can use only bitshift and multiplication at inference.
-        l0_ = torch.cat(l0_s1, dim=1) * self.quantization.l0_correction_factor
+        l0_ = l0_ * self.quantization.l0_correction_factor
+
+        if fake_quantize_acts:
+            l0_ = self.quantization.fake_quantize_ft_act(l0_)
 
         return l0_, wpsqt, bpsqt
 

--- a/model/model.py
+++ b/model/model.py
@@ -99,6 +99,8 @@ class NNUEModel(nn.Module):
         l0_s1 = [l0_s[0] * l0_s[1], l0_s[2] * l0_s[3]]
         l0_ = torch.cat(l0_s1, dim=1)
 
+        # We multiply by a correction factor, so we can use only bitshift and multiplication at inference.
+        l0_ = l0_ * self.quantization.l0_correction_factor
         if fake_quantize_acts:
             # after Hadamard product act_scale is converted
             # so it should be `fake_quantize_ls_act`
@@ -106,8 +108,6 @@ class NNUEModel(nn.Module):
             # `fake_quantize_ft_act` leads to a lower cross_eval error....
             l0_ = self.quantization.fake_quantize_ls_act(l0_)
 
-        # We multiply by a correction factor, so we can use only bitshift and multiplication at inference.
-        l0_ = l0_ * self.quantization.l0_correction_factor
 
         return l0_, wpsqt, bpsqt
 

--- a/model/model.py
+++ b/model/model.py
@@ -90,16 +90,9 @@ class NNUEModel(nn.Module):
         bpsqt = bpsqt.gather(1, psqt_indices_unsq)
 
         l0_ = (us * torch.cat([w, b], dim=1)) + (them * torch.cat([b, w], dim=1))
-        l0_ = torch.clamp(l0_, 0.0, self.quantization.max_ft_activation)
         if fake_quantize_acts:
-            # Fake quantization with STE
-            # NOTE if we use fake quantization in more spots,
-            # we should refactor this into its own class
-            # Inference uses bitshift which is equivalent to rounding down (floor).
-            act_scale = self.quantization.config.inference_l0_division_factor
-            l0_hard = ((l0_ * act_scale).floor() / act_scale).detach()
-            l0_soft = l0_.detach()
-            l0_ = l0_hard + (l0_ - l0_soft)
+            l0_ = self.quantization.fake_quantize_ft_act(l0_)
+        l0_ = self.quantization.clip_ft_act(l0_)
 
         l0_s = torch.split(l0_, self.L1 // 2, dim=1)
         l0_s1 = [l0_s[0] * l0_s[1], l0_s[2] * l0_s[3]]
@@ -119,7 +112,7 @@ class NNUEModel(nn.Module):
         black_values: torch.Tensor,
         psqt_indices: torch.Tensor,
         layer_stack_indices: torch.Tensor,
-        fake_quantize_acts: bool=False,
+        fake_quantize_acts: bool=True,
     ):
         l0_, wpsqt, bpsqt = self.forward_ft(
             us,
@@ -134,6 +127,6 @@ class NNUEModel(nn.Module):
         # The PSQT values are averaged over perspectives. "Their" perspective
         # has a negative influence (us-0.5 is 0.5 for white and -0.5 for black,
         # which does both the averaging and sign flip for black to move)
-        x = self.layer_stacks(l0_, layer_stack_indices) + (wpsqt - bpsqt) * (us - 0.5)
+        x = self.layer_stacks(l0_, layer_stack_indices, fake_quantize_acts) + (wpsqt - bpsqt) * (us - 0.5)
 
         return x

--- a/model/model.py
+++ b/model/model.py
@@ -99,9 +99,6 @@ class NNUEModel(nn.Module):
         l0_s1 = [l0_s[0] * l0_s[1], l0_s[2] * l0_s[3]]
         l0_ = torch.cat(l0_s1, dim=1)
 
-        # We multiply by a correction factor, so we can use only bitshift and multiplication at inference.
-        l0_ = l0_ * self.quantization.l0_correction_factor
-
         if fake_quantize_acts:
             # after Hadamard product act_scale is converted
             # so it should be `fake_quantize_ls_act`
@@ -109,6 +106,8 @@ class NNUEModel(nn.Module):
             # `fake_quantize_ft_act` leads to a lower cross_eval error....
             l0_ = self.quantization.fake_quantize_ls_act(l0_)
 
+        # We multiply by a correction factor, so we can use only bitshift and multiplication at inference.
+        l0_ = l0_ * self.quantization.l0_correction_factor
 
         return l0_, wpsqt, bpsqt
 

--- a/model/model.py
+++ b/model/model.py
@@ -38,11 +38,14 @@ class NNUEModel(nn.Module):
         self.input.init_weights(num_psqt_buckets, self.quantization.nnue2score)
 
     @torch.no_grad()
-    def clip_weights(self):
+    def clip_weights(self, include_input: bool):
         """
         Clips the weights of the model based on the min/max values allowed
         by the quantization scheme.
         """
+        if include_input:
+            self.input.clip_weights(self.quantization)
+
         for group in self.weight_clipping:
             for p in group["params"]:
                 if "min_weight" in group or "max_weight" in group:
@@ -65,10 +68,6 @@ class NNUEModel(nn.Module):
                                 - expanded_virtual_layer
                             )
                     p_data_fp32.clamp_(min_weight, max_weight)
-
-
-    def clip_input_weights(self):
-        self.input.clip_weights(self.quantization)
 
 
     def forward_ft(
@@ -104,6 +103,9 @@ class NNUEModel(nn.Module):
 
         if fake_quantize_acts:
             # after Hadamard product act_scale is converted
+            # so it should be `fake_quantize_ls_act`
+            # TODO: Find out why
+            # `fake_quantize_ft_act` leads to a lower cross_eval error....
             l0_ = self.quantization.fake_quantize_ls_act(l0_)
 
         return l0_, wpsqt, bpsqt

--- a/model/model.py
+++ b/model/model.py
@@ -3,7 +3,7 @@ from torch import nn
 
 from .config import ModelConfig
 from .modules import LayerStacks, get_feature_cls
-from .quantize import QuantizationConfig, QuantizationManager
+from .quantize import QuantizationManager
 
 
 class NNUEModel(nn.Module):
@@ -11,7 +11,6 @@ class NNUEModel(nn.Module):
         self,
         feature_name: str,
         config: ModelConfig,
-        quantize_config: QuantizationConfig,
         num_psqt_buckets: int = 8,
         num_ls_buckets: int = 8,
     ):
@@ -22,6 +21,9 @@ class NNUEModel(nn.Module):
         self.L2 = config.L2
         self.L3 = config.L3
 
+        self.quantize_config = config.quantize_config
+        self.quantization = QuantizationManager(config.quantize_config)
+
         self.num_psqt_buckets = num_psqt_buckets
         self.num_ls_buckets = num_ls_buckets
 
@@ -29,9 +31,8 @@ class NNUEModel(nn.Module):
         self.feature_name = self.input.FEATURE_NAME
         self.input_feature_name = self.input.INPUT_FEATURE_NAME
         self.feature_hash = self.input.HASH
-        self.layer_stacks = LayerStacks(self.num_ls_buckets, config)
+        self.layer_stacks = LayerStacks(self.num_ls_buckets, config, self.quantization)
 
-        self.quantization = QuantizationManager(quantize_config)
         self.weight_clipping = self.quantization.generate_weight_clipping_config(self)
 
         self.input.init_weights(num_psqt_buckets, self.quantization.nnue2score)
@@ -83,13 +84,12 @@ class NNUEModel(nn.Module):
         w, wpsqt = torch.split(wp, self.L1, dim=1)
         b, bpsqt = torch.split(bp, self.L1, dim=1)
         l0_ = (us * torch.cat([w, b], dim=1)) + (them * torch.cat([b, w], dim=1))
-        l0_ = torch.clamp(l0_, 0.0, 1.0)
+        l0_ = torch.clamp(l0_, 0.0, self.quantization.max_ft_activation)
 
         l0_s = torch.split(l0_, self.L1 // 2, dim=1)
         l0_s1 = [l0_s[0] * l0_s[1], l0_s[2] * l0_s[3]]
-        # We multiply by 127/128 because in the quantized network 1.0 is represented by 127
-        # and it's more efficient to divide by 128 instead.
-        l0_ = torch.cat(l0_s1, dim=1) * (127 / 128)
+        # We multiply by a correction factor, so we can use only bitshift and multiplication at inference.
+        l0_ = torch.cat(l0_s1, dim=1) * self.quantization.l0_correction_factor
 
         psqt_indices_unsq = psqt_indices.unsqueeze(dim=1)
         wpsqt = wpsqt.gather(1, psqt_indices_unsq)

--- a/model/modules/layer_stacks.py
+++ b/model/modules/layer_stacks.py
@@ -40,10 +40,10 @@ class LayerStacks(nn.Module):
 
         l1_sqr = torch.pow(l1x_, 2.0)
 
-        # multiply sqr crelu result by scale correction to match quantized version
-        l1_sqr = l1_sqr * (self.quantization.sqr_crelu_correction_factor)
         if fake_quantize_acts:
             l1_sqr = self.quantization.fake_quantize_ls_act(l1_sqr)
+        # multiply sqr crelu result by scale correction to match quantized version
+        l1_sqr = l1_sqr * (self.quantization.sqr_crelu_correction_factor)
 
         l1x_ = self.quantization.clip_ls_act(
             torch.cat([l1_sqr, l1x_], dim=1)

--- a/model/modules/layer_stacks.py
+++ b/model/modules/layer_stacks.py
@@ -38,9 +38,9 @@ class LayerStacks(nn.Module):
             l1c_ = self.quantization.fake_quantize_ls_act(l1c_)
         l1x_, l1x_out = l1c_.split(self.L2, dim=1)
 
+        l1_sqr = torch.pow(l1x_, 2.0)
         if fake_quantize_acts:
             l1_sqr = self.quantization.fake_quantize_ls_act(l1_sqr)
-        l1_sqr = torch.pow(l1x_, 2.0)
         # multiply sqr crelu result by scale correction to match quantized version
         l1_sqr = l1_sqr * (self.quantization.sqr_crelu_correction_factor)
 

--- a/model/modules/layer_stacks.py
+++ b/model/modules/layer_stacks.py
@@ -38,11 +38,11 @@ class LayerStacks(nn.Module):
             l1c_ = self.quantization.fake_quantize_ls_act(l1c_)
         l1x_, l1x_out = l1c_.split(self.L2, dim=1)
 
-        l1_sqr = l1_sqr * (self.quantization.sqr_crelu_correction_factor)
         if fake_quantize_acts:
             l1_sqr = self.quantization.fake_quantize_ls_act(l1_sqr)
         l1_sqr = torch.pow(l1x_, 2.0)
         # multiply sqr crelu result by scale correction to match quantized version
+        l1_sqr = l1_sqr * (self.quantization.sqr_crelu_correction_factor)
 
         l1x_ = self.quantization.clip_ls_act(
             torch.cat([l1_sqr, l1x_], dim=1)

--- a/model/modules/layer_stacks.py
+++ b/model/modules/layer_stacks.py
@@ -38,11 +38,11 @@ class LayerStacks(nn.Module):
             l1c_ = self.quantization.fake_quantize_ls_act(l1c_)
         l1x_, l1x_out = l1c_.split(self.L2, dim=1)
 
-        l1_sqr = torch.pow(l1x_, 2.0)
-        # multiply sqr crelu result by scale correction to match quantized version
         l1_sqr = l1_sqr * (self.quantization.sqr_crelu_correction_factor)
         if fake_quantize_acts:
             l1_sqr = self.quantization.fake_quantize_ls_act(l1_sqr)
+        l1_sqr = torch.pow(l1x_, 2.0)
+        # multiply sqr crelu result by scale correction to match quantized version
 
         l1x_ = self.quantization.clip_ls_act(
             torch.cat([l1_sqr, l1x_], dim=1)

--- a/model/modules/layer_stacks.py
+++ b/model/modules/layer_stacks.py
@@ -39,11 +39,10 @@ class LayerStacks(nn.Module):
         l1x_, l1x_out = l1c_.split(self.L2, dim=1)
 
         l1_sqr = torch.pow(l1x_, 2.0)
-
-        if fake_quantize_acts:
-            l1_sqr = self.quantization.fake_quantize_ls_act(l1_sqr)
         # multiply sqr crelu result by scale correction to match quantized version
         l1_sqr = l1_sqr * (self.quantization.sqr_crelu_correction_factor)
+        if fake_quantize_acts:
+            l1_sqr = self.quantization.fake_quantize_ls_act(l1_sqr)
 
         l1x_ = self.quantization.clip_ls_act(
             torch.cat([l1_sqr, l1x_], dim=1)

--- a/model/modules/layer_stacks.py
+++ b/model/modules/layer_stacks.py
@@ -37,8 +37,11 @@ class LayerStacks(nn.Module):
         if fake_quantize_acts:
             l1c_ = self.quantization.fake_quantize_ls_act(l1c_)
         l1x_, l1x_out = l1c_.split(self.L2, dim=1)
+
+        l1_sqr = torch.pow(l1x_, 2.0)
+
         # multiply sqr crelu result by scale correction to match quantized version
-        l1_sqr = torch.pow(l1x_, 2.0) * (self.quantization.sqr_crelu_correction_factor)
+        l1_sqr = l1_sqr * (self.quantization.sqr_crelu_correction_factor)
         if fake_quantize_acts:
             l1_sqr = self.quantization.fake_quantize_ls_act(l1_sqr)
 
@@ -54,6 +57,7 @@ class LayerStacks(nn.Module):
         l3c_ = self.output(l2x_, ls_indices)
         if fake_quantize_acts:
             l3c_ = self.quantization.fake_quantize_ls_act(l3c_)
+            l1x_out = self.quantization.fake_quantize_skip_act(l1x_out)
 
         l3x_ = l3c_ + l1x_out
         if fake_quantize_acts:

--- a/model/modules/layer_stacks.py
+++ b/model/modules/layer_stacks.py
@@ -28,22 +28,32 @@ class LayerStacks(nn.Module):
         with torch.no_grad():
             self.output.linear.bias.zero_()
 
-    def forward(self, x: torch.Tensor, ls_indices: torch.Tensor):
+    def forward(
+        self, x: torch.Tensor,
+        ls_indices: torch.Tensor,
+        fake_quantize_acts: bool=False,
+    ):
         l1c_ = self.l1(x, ls_indices)
+        if fake_quantize_acts:
+            l1c_ = self.quantization.fake_quantize_ls_act(l1c_)
         l1x_, l1x_out = l1c_.split(self.L2, dim=1)
         # multiply sqr crelu result by scale correction to match quantized version
-        l1x_ = torch.clamp(
-            torch.cat([torch.pow(l1x_, 2.0) * (self.quantization.sqr_crelu_correction_factor), l1x_], dim=1),
-            0.0,
-            self.quantization.max_hidden_activation,
+        l1x_ = self.quantization.clip_ls_act(
+            torch.cat([torch.pow(l1x_, 2.0) * (self.quantization.sqr_crelu_correction_factor), l1x_], dim=1)
         )
 
         l2c_ = self.l2(l1x_, ls_indices)
-        l2x_ = torch.clamp(l2c_, 0.0, self.quantization.max_hidden_activation)
+        if fake_quantize_acts:
+            l2c_ = self.quantization.fake_quantize_ls_act(l2c_)
+        l2x_ = self.quantization.clip_ls_act(l2c_)
 
         l3c_ = self.output(l2x_, ls_indices)
-        l3x_ = l3c_ + l1x_out
+        if fake_quantize_acts:
+            l3c_ = self.quantization.fake_quantize_ls_act(l3c_)
 
+        l3x_ = l3c_ + l1x_out
+        if fake_quantize_acts:
+            l3x_ = self.quantization.fake_quantize_ls_act(l3x_)
         return l3x_
 
     @torch.no_grad()

--- a/model/modules/layer_stacks.py
+++ b/model/modules/layer_stacks.py
@@ -5,16 +5,17 @@ from torch import nn
 
 from .stacked_linear import FactorizedStackedLinear, StackedLinear
 from .config import LayerStacksConfig
-
+from ..quantize import QuantizationManager
 
 class LayerStacks(nn.Module):
-    def __init__(self, count: int, config: LayerStacksConfig):
+    def __init__(self, count: int, config: LayerStacksConfig, quantization: QuantizationManager):
         super().__init__()
 
         self.count = count
         self.L1 = config.L1
         self.L2 = config.L2
         self.L3 = config.L3
+        self.quantization = quantization
 
         # Factorizer only for the first layer because later
         # there's a non-linearity and factorization breaks.
@@ -30,13 +31,15 @@ class LayerStacks(nn.Module):
     def forward(self, x: torch.Tensor, ls_indices: torch.Tensor):
         l1c_ = self.l1(x, ls_indices)
         l1x_, l1x_out = l1c_.split(self.L2, dim=1)
-        # multiply sqr crelu result by (255/256) to match quantized version
+        # multiply sqr crelu result by scale correction to match quantized version
         l1x_ = torch.clamp(
-            torch.cat([torch.pow(l1x_, 2.0) * (255 / 256), l1x_], dim=1), 0.0, 1.0
+            torch.cat([torch.pow(l1x_, 2.0) * (self.quantization.sqr_crelu_correction_factor), l1x_], dim=1),
+            0.0,
+            self.quantization.max_hidden_activation,
         )
 
         l2c_ = self.l2(l1x_, ls_indices)
-        l2x_ = torch.clamp(l2c_, 0.0, 1.0)
+        l2x_ = torch.clamp(l2c_, 0.0, self.quantization.max_hidden_activation)
 
         l3c_ = self.output(l2x_, ls_indices)
         l3x_ = l3c_ + l1x_out

--- a/model/modules/layer_stacks.py
+++ b/model/modules/layer_stacks.py
@@ -38,8 +38,12 @@ class LayerStacks(nn.Module):
             l1c_ = self.quantization.fake_quantize_ls_act(l1c_)
         l1x_, l1x_out = l1c_.split(self.L2, dim=1)
         # multiply sqr crelu result by scale correction to match quantized version
+        l1_sqr = torch.pow(l1x_, 2.0) * (self.quantization.sqr_crelu_correction_factor)
+        if fake_quantize_acts:
+            l1_sqr = self.quantization.fake_quantize_ls_act(l1_sqr)
+
         l1x_ = self.quantization.clip_ls_act(
-            torch.cat([torch.pow(l1x_, 2.0) * (self.quantization.sqr_crelu_correction_factor), l1x_], dim=1)
+            torch.cat([l1_sqr, l1x_], dim=1)
         )
 
         l2c_ = self.l2(l1x_, ls_indices)

--- a/model/modules/layer_stacks.py
+++ b/model/modules/layer_stacks.py
@@ -59,8 +59,6 @@ class LayerStacks(nn.Module):
             l1x_out = self.quantization.fake_quantize_skip_act(l1x_out)
 
         l3x_ = l3c_ + l1x_out
-        if fake_quantize_acts:
-            l3x_ = self.quantization.fake_quantize_ls_act(l3x_)
         return l3x_
 
     @torch.no_grad()

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -97,7 +97,9 @@ class QuantizationManager:
         return torch.clamp(preact, 0, self.max_hidden_activation)
 
     def fake_quantize_ft_act(self, preact):
-        act_scale = self.config.ft_quantized_one
+        # TODO theoretically correct value is worse somehow
+        # act_scale = self.config.hidden_quantized_one
+        act_scale =  self.config.ft_quantized_one
         return _fake_quantize(preact, act_scale)
 
     def fake_quantize_ls_act(self, preact):

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -44,6 +44,7 @@ class QuantizationConfig:
 
 class QuantizationManager:
     def __init__(self, config: QuantizationConfig):
+        self.config = config
         self.nnue2score = config.nnue2score
         self.weight_scale_hidden = [
             config.weight_scale_l1,

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Callable, NotRequired, TypedDict, TYPE_CHECKING
+from typing import Optional, Callable, NotRequired, TypedDict, TYPE_CHECKING
 
 import torch
 
@@ -13,44 +13,76 @@ class WeightClippingConfig(TypedDict):
     max_weight: float
     virtual_params: NotRequired[torch.Tensor]
 
+def _safe_convert(value: torch.Tensor, target_dtype: torch.dtype):
+    _info = torch.iinfo(target_dtype)
+    # Symmetric range: [-max, max]
+    min_val = -_info.max
+    max_val = _info.max
 
-def safe_convert(tensor: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
-    info = torch.iinfo(dtype)
-    t_min = tensor.min().item()
-    t_max = tensor.max().item()
-    if t_min < info.min or t_max > info.max:
-        raise OverflowError(
-            f"values [{t_min}, {t_max}] do not fit in {dtype} "
-            f"range [{info.min}, {info.max}]"
-        )
-    return tensor.to(dtype)
-
+    rounded_value = value.round()
+    clamped_value = rounded_value.clamp(min_val, max_val)
+    num_clipped = (rounded_value != clamped_value).sum()
+    quantized_value = clamped_value.to(target_dtype)
+    return quantized_value, num_clipped
 
 @dataclass
 class QuantizationConfig:
     nnue2score: float = 600.0
-    weight_scale_hidden: float = 64.0
-    weight_scale_out: float = 16.0
-    ft_quantized_one: float = 255.0
-    hidden_quantized_one: float = 127.0
+    weight_scale_l1: float = 128.0 # TODO 128 is better empirically for this layer
+    weight_scale_l2: float = 64.0
+    # weight_scale_out = (self.nnue2score * self.weight_scale_out) / self.hidden_quantized_one
+    weight_scale_l_out: float = (600.0 * 16) / 128 # TODO 128 is better empirically for this layer
+    weight_scale_out: float = 16.0 # TODO do calculation conversion on inference side
+    weight_quantized_max_hidden: float = 127.0 # i8 max
+    ft_quantized_one: float = 255.0 # TODO 255 is easier and does not require any adjustment factor
+    ft_quantized_max: float = 255.0 # limited to 255 for safe squaring within i16
+    hidden_quantized_one: float = 127.0 # TODO 128 is easier and does not require any adjustment factor
+    hidden_quantized_max: float = 127.0 # i8 max
+    inference_l0_division_factor: float = 512.0
+    inference_sqr_crelu_division_factor: float = 128.0
 
 
 class QuantizationManager:
     def __init__(self, config: QuantizationConfig):
         self.nnue2score = config.nnue2score
-        self.weight_scale_hidden = config.weight_scale_hidden
+        self.weight_scale_hidden = [
+            config.weight_scale_l1,
+            config.weight_scale_l2,
+            config.weight_scale_l_out,
+        ]
         self.weight_scale_out = config.weight_scale_out
+        self.weight_quantized_max_hidden = config.weight_quantized_max_hidden
         self.hidden_quantized_one = config.hidden_quantized_one
         self.ft_quantized_one = config.ft_quantized_one
 
-        self.max_hidden_weight = config.hidden_quantized_one / self.weight_scale_hidden
-        # Threat weights are quantized to symmetric int8 after scaling by ft_quantized_one
+        hidden_q_max = config.weight_quantized_max_hidden
+        self.max_hidden_weight = [hidden_q_max / scale for scale in self.weight_scale_hidden]
+        # Threat weights are treated separately. A bit hacky...
+        # Threat weights are quantized to int8 after scaling by ft_quantized_one
         _i8 = torch.iinfo(torch.int8)
-        self.min_threat_weight = -_i8.max / config.ft_quantized_one  # -127/255
-        self.max_threat_weight = _i8.max / config.ft_quantized_one  # 127/255
-        self.max_out_weight = (
-            config.hidden_quantized_one * self.hidden_quantized_one
-        ) / (self.nnue2score * self.weight_scale_out)
+        self.min_threat_weight = -_i8.max / config.ft_quantized_one  # -127/256
+        self.max_threat_weight = _i8.max / config.ft_quantized_one  # 127/256
+
+        self._l0_correction_factor = config.ft_quantized_one ** 2 / config.inference_l0_division_factor / self.hidden_quantized_one
+        self._sqr_crelu_correction_factor = config.hidden_quantized_one / config.inference_sqr_crelu_division_factor
+        self._max_ft_activation = config.ft_quantized_max / config.ft_quantized_one
+        self._max_hidden_activation = config.hidden_quantized_max / config.hidden_quantized_one
+
+    @property
+    def l0_correction_factor(self):
+        return self._l0_correction_factor
+
+    @property
+    def sqr_crelu_correction_factor(self):
+        return self._sqr_crelu_correction_factor
+
+    @property
+    def max_ft_activation(self):
+        return self._max_ft_activation
+
+    @property
+    def max_hidden_activation(self):
+        return self._max_hidden_activation
 
     def generate_weight_clipping_config(
         self, model: "NNUEModel"
@@ -58,37 +90,51 @@ class QuantizationManager:
         return [
             {
                 "params": [model.layer_stacks.l1.linear.weight],
-                "min_weight": -self.max_hidden_weight,
-                "max_weight": self.max_hidden_weight,
+                "min_weight": -self.max_hidden_weight[0],
+                "max_weight": self.max_hidden_weight[0],
                 "virtual_params": model.layer_stacks.l1.factorized_linear.weight,
             },
             {
                 "params": [model.layer_stacks.l2.linear.weight],
-                "min_weight": -self.max_hidden_weight,
-                "max_weight": self.max_hidden_weight,
+                "min_weight": -self.max_hidden_weight[1],
+                "max_weight": self.max_hidden_weight[1],
             },
             {
                 "params": [model.layer_stacks.output.linear.weight],
-                "min_weight": -self.max_out_weight,
-                "max_weight": self.max_out_weight,
+                "min_weight": -self.max_hidden_weight[2],
+                "max_weight": self.max_hidden_weight[2],
             },
         ]
 
     def quantize_feature_transformer(
         self,
-        bias: torch.Tensor,
-        weight: torch.Tensor,
-        psqt_weight: torch.Tensor,
-        callback: Callable = lambda *args, **kwargs: None,
+        bias: Optional[torch.Tensor],
+        weight: Optional[torch.Tensor],
+        psqt_weight: Optional[torch.Tensor],
+        f_weight_export_dtype: torch.dtype = torch.int16,
+        callback: Optional[Callable] = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        bias = safe_convert(bias.mul(self.ft_quantized_one).round(), torch.int16)
-        weight = safe_convert(weight.mul(self.ft_quantized_one).round(), torch.int16)
-        psqt_weight = safe_convert(
-            psqt_weight.mul(self.nnue2score * self.weight_scale_out).round(),
-            torch.int32,
-        )
+        if bias is not None:
+            # only weight can have different dtypes, bias is always int16, psqt_weight is always int32
+            bias = bias.mul(self.ft_quantized_one)
+            bias, bias_clipped = _safe_convert(bias, torch.int16)
 
-        callback(bias, weight, psqt_weight)
+            if callback is not None:
+                callback("ft_bias", bias, bias_clipped)
+
+        if weight is not None:
+            weight = weight.mul(self.ft_quantized_one)
+            weight, weight_clipped = _safe_convert(weight, f_weight_export_dtype)
+
+            if callback is not None:
+                callback("ft_weight", weight, weight_clipped)
+
+        if psqt_weight is not None:
+            psqt_weight = psqt_weight.mul(self.nnue2score * self.weight_scale_out)
+            psqt_weight, psqt_weight_clipped = _safe_convert(psqt_weight, torch.int32)
+
+            if callback is not None:
+                callback("psqt_weight", psqt_weight, psqt_weight_clipped)
 
         return bias, weight, psqt_weight
 
@@ -98,9 +144,9 @@ class QuantizationManager:
         weight: torch.Tensor,
         psqt_weight: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        bias = bias.divide(self.ft_quantized_one)
-        weight = weight.divide(self.ft_quantized_one)
-        psqt_weight = psqt_weight.divide(self.nnue2score * self.weight_scale_out)
+        bias = bias.divide(self.ft_quantized_one) if bias is not None else None
+        weight = weight.divide(self.ft_quantized_one) if weight is not None else None
+        psqt_weight = psqt_weight.divide(self.nnue2score * self.weight_scale_out) if psqt_weight is not None else None
 
         return bias, weight, psqt_weight
 
@@ -108,35 +154,18 @@ class QuantizationManager:
         self,
         bias: torch.Tensor,
         weight: torch.Tensor,
-        output_layer: bool = False,
-        callback: Callable = lambda *args, **kwargs: None,
+        layer_idx: int,
+        callback: Optional[Callable] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        kWeightScaleHidden = self.weight_scale_hidden
-        kWeightScaleOut = (
-            self.nnue2score * self.weight_scale_out / self.hidden_quantized_one
-        )
-        kWeightScale = kWeightScaleOut if output_layer else kWeightScaleHidden
-        kBiasScaleOut = self.weight_scale_out * self.nnue2score
-        kBiasScaleHidden = self.weight_scale_hidden * self.hidden_quantized_one
-        kBiasScale = kBiasScaleOut if output_layer else kBiasScaleHidden
-        kMaxWeight = self.hidden_quantized_one / kWeightScale
+        kBiasScaleHidden = self.weight_scale_hidden[layer_idx] * self.hidden_quantized_one
+        kWeightScaleHidden = self.weight_scale_hidden[layer_idx]
 
-        bias = safe_convert(bias.mul(kBiasScale).round(), torch.int32)
+        bias, bias_clipped = _safe_convert(bias.mul(kBiasScaleHidden), torch.int32)
+        weight, weight_clipped = _safe_convert(weight.mul(kWeightScaleHidden), torch.int8)
 
-        clipped = torch.count_nonzero(weight.clamp(-kMaxWeight, kMaxWeight) - weight)
-        total_elements = torch.numel(weight)
-        clipped_max = torch.max(
-            torch.abs(weight.clamp(-kMaxWeight, kMaxWeight) - weight)
-        )
-
-        weight = (
-            weight.clamp(-kMaxWeight, kMaxWeight)
-            .mul(kWeightScale)
-            .round()
-            .to(torch.int8)
-        )
-
-        callback(bias, weight, clipped, total_elements, clipped_max, kMaxWeight)
+        if callback is not None:
+            callback("fc_weight", weight, weight_clipped)
+            callback("fc_bias", bias, bias_clipped)
 
         return bias, weight
 
@@ -144,18 +173,12 @@ class QuantizationManager:
         self,
         bias: torch.Tensor,
         weight: torch.Tensor,
-        output_layer: bool = False,
+        layer_idx: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        kWeightScaleHidden = self.weight_scale_hidden
-        kWeightScaleOut = (
-            self.nnue2score * self.weight_scale_out / self.hidden_quantized_one
-        )
-        kWeightScale = kWeightScaleOut if output_layer else kWeightScaleHidden
-        kBiasScaleOut = self.weight_scale_out * self.nnue2score
-        kBiasScaleHidden = self.weight_scale_hidden * self.hidden_quantized_one
-        kBiasScale = kBiasScaleOut if output_layer else kBiasScaleHidden
+        kBiasScaleHidden = self.weight_scale_hidden[layer_idx] * self.hidden_quantized_one
+        kWeightScaleHidden = self.weight_scale_hidden[layer_idx]
 
-        bias = bias.divide(kBiasScale)
-        weight = weight.divide(kWeightScale)
+        bias = bias.divide(kBiasScaleHidden)
+        weight = weight.divide(kWeightScaleHidden)
 
         return bias, weight

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -104,12 +104,7 @@ class QuantizationManager:
         return _fake_quantize(preact, act_scale)
 
     def fake_quantize_skip_act(self, preact):
-        # (600 * OutputScale) / (127 * (1 << WeightScaleBits))
-        act_scale = 1 / (self.hidden_quantized_one * self.config.weight_scale_l1)
-        tmp_scale = self.nnue2score * self.weight_scale_out * self.hidden_quantized_one
-        out = preact * tmp_scale
-        out = _fake_quantize(preact, act_scale)
-        return out / tmp_scale
+        return preact # TODO needs inference changes to be effective
 
     def generate_weight_clipping_config(
         self, model: "NNUEModel"

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -23,7 +23,20 @@ def _safe_convert(value: torch.Tensor, target_dtype: torch.dtype):
     clamped_value = rounded_value.clamp(min_val, max_val)
     num_clipped = (rounded_value != clamped_value).sum()
     quantized_value = clamped_value.to(target_dtype)
+
     return quantized_value, num_clipped
+
+def _fake_quantize(value, act_scale):
+    # Fake quantization with STE
+    # Inference uses bitshift which is equivalent to rounding down (floor).
+    # act_scale is in nnue-pytorch is `> 1`, inverted compared to normal literature.
+    # will be slightly inaccurate unless all corrections factors are 1.0.
+    value_hard = ((value * act_scale).floor() / act_scale).detach()
+    value_soft = value.detach()
+    value = value_hard + (value - value_soft)
+
+    return value
+
 
 @dataclass
 class QuantizationConfig:
@@ -84,6 +97,20 @@ class QuantizationManager:
     @property
     def max_hidden_activation(self):
         return self._max_hidden_activation
+
+    def clip_ft_act(self, preact):
+        return torch.clamp(preact, 0.0, self.max_ft_activation)
+
+    def fake_quantize_ft_act(self, preact):
+        act_scale = self.config.ft_quantized_one
+        return _fake_quantize(preact, act_scale)
+
+    def clip_ls_act(self, preact):
+        return torch.clamp(preact, 0, self.max_hidden_activation)
+
+    def fake_quantize_ls_act(self, preact):
+        act_scale = self.config.hidden_quantized_one
+        return _fake_quantize(preact, act_scale)
 
     def generate_weight_clipping_config(
         self, model: "NNUEModel"

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -28,9 +28,9 @@ def _safe_convert(value: torch.Tensor, target_dtype: torch.dtype):
 @dataclass
 class QuantizationConfig:
     nnue2score: float = 600.0
-    weight_scale_hidden_0: float = 128.0
-    weight_scale_hidden_1: float = 64.0
-    weight_scale_hidden_2: float = 128.0
+    weight_scale_l1: float = 128.0
+    weight_scale_l2: float = 64.0
+    weight_scale_output: float = 128.0
     weight_scale_out: float = 16.0
     weight_quantized_max_hidden: float = 127.0 # i8 max
     ft_quantized_one: float = 256.0
@@ -44,9 +44,9 @@ class QuantizationManager:
     def __init__(self, config: QuantizationConfig):
         self.nnue2score = config.nnue2score
         self.weight_scale_hidden = [
-            config.weight_scale_hidden_0,
-            config.weight_scale_hidden_1,
-            config.weight_scale_hidden_2,
+            config.weight_scale_l1,
+            config.weight_scale_l2,
+            config.weight_scale_output,
         ]
         self.weight_scale_out = config.weight_scale_out
         self.weight_quantized_max_hidden = config.weight_quantized_max_hidden

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -51,6 +51,8 @@ class QuantizationConfig:
     ft_quantized_max: float = 255.0 # limited to 255 for safe squaring within i16
     hidden_quantized_one: float = 127.0 # TODO 128 is easier and does not require any adjustment factor
     hidden_quantized_max: float = 127.0 # i8 max
+
+    # used to calculate correction factors
     inference_l0_division_factor: float = 512.0
     inference_sqr_crelu_division_factor: float = 128.0
 

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -6,7 +6,7 @@ import torch
 if TYPE_CHECKING:
     from .model import NNUEModel
 
-FAKE_QUANTIZE_EPS = 1e-5
+FAKE_QUANTIZE_EPS = 1e-3
 
 class WeightClippingConfig(TypedDict):
     params: list[torch.Tensor]

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Callable, NotRequired, TypedDict, TYPE_CHECKING
+from typing import Optional, Callable, NotRequired, TypedDict, TYPE_CHECKING
 
 import torch
 
@@ -13,32 +13,74 @@ class WeightClippingConfig(TypedDict):
     max_weight: float
     virtual_params: NotRequired[torch.Tensor]
 
+def _safe_convert(value: torch.Tensor, target_dtype: torch.dtype):
+    _info = torch.iinfo(target_dtype)
+    # Symmetric range: [-max, max]
+    min_val = -_info.max
+    max_val = _info.max
+
+    rounded_value = value.round()
+    clamped_value = rounded_value.clamp(min_val, max_val)
+    num_clipped = (rounded_value != clamped_value).sum()
+    quantized_value = clamped_value.to(target_dtype)
+    return quantized_value, num_clipped
 
 @dataclass
 class QuantizationConfig:
     nnue2score: float = 600.0
-    weight_scale_hidden: float = 64.0
+    weight_scale_hidden_0: float = 128.0
+    weight_scale_hidden_1: float = 64.0
+    weight_scale_hidden_2: float = 128.0
     weight_scale_out: float = 16.0
-    ft_quantized_one: float = 255.0
-    hidden_quantized_one: float = 127.0
-
+    weight_quantized_max_hidden: float = 127.0 # i8 max
+    ft_quantized_one: float = 256.0
+    ft_quantized_max: float = 255.0 # limited to 255 for safe squaring within i16
+    hidden_quantized_one: float = 128.0
+    hidden_quantized_max: float = 127.0 # i8 max
+    inference_l0_division_factor: float = 512.0
+    inference_sqr_crelu_division_factor: float = 128.0
 
 class QuantizationManager:
     def __init__(self, config: QuantizationConfig):
         self.nnue2score = config.nnue2score
-        self.weight_scale_hidden = config.weight_scale_hidden
+        self.weight_scale_hidden = [
+            config.weight_scale_hidden_0,
+            config.weight_scale_hidden_1,
+            config.weight_scale_hidden_2,
+        ]
         self.weight_scale_out = config.weight_scale_out
+        self.weight_quantized_max_hidden = config.weight_quantized_max_hidden
         self.hidden_quantized_one = config.hidden_quantized_one
         self.ft_quantized_one = config.ft_quantized_one
 
-        self.max_hidden_weight = config.hidden_quantized_one / self.weight_scale_hidden
+        hidden_q_max = config.weight_quantized_max_hidden
+        self.max_hidden_weight = [hidden_q_max / scale for scale in self.weight_scale_hidden]
+        # Threat weights are treated separately. A bit hacky...
         # Threat weights are quantized to int8 after scaling by ft_quantized_one
         _i8 = torch.iinfo(torch.int8)
-        self.min_threat_weight = _i8.min / config.ft_quantized_one  # -128/255
-        self.max_threat_weight = _i8.max / config.ft_quantized_one  # 127/255
-        self.max_out_weight = (
-            config.hidden_quantized_one * self.hidden_quantized_one
-        ) / (self.nnue2score * self.weight_scale_out)
+        self.min_threat_weight = -_i8.max / config.ft_quantized_one  # -127/256
+        self.max_threat_weight = _i8.max / config.ft_quantized_one  # 127/256
+
+        self._l0_correction_factor = config.ft_quantized_one ** 2 / config.inference_l0_division_factor / self.hidden_quantized_one
+        self._sqr_crelu_correction_factor = config.hidden_quantized_one / config.inference_sqr_crelu_division_factor
+        self._max_ft_activation = config.ft_quantized_max / config.ft_quantized_one
+        self._max_hidden_activation = config.hidden_quantized_max / config.hidden_quantized_one
+
+    @property
+    def l0_correction_factor(self):
+        return self._l0_correction_factor
+
+    @property
+    def sqr_crelu_correction_factor(self):
+        return self._sqr_crelu_correction_factor
+
+    @property
+    def max_ft_activation(self):
+        return self._max_ft_activation
+
+    @property
+    def max_hidden_activation(self):
+        return self._max_hidden_activation
 
     def generate_weight_clipping_config(
         self, model: "NNUEModel"
@@ -46,38 +88,51 @@ class QuantizationManager:
         return [
             {
                 "params": [model.layer_stacks.l1.linear.weight],
-                "min_weight": -self.max_hidden_weight,
-                "max_weight": self.max_hidden_weight,
+                "min_weight": -self.max_hidden_weight[0],
+                "max_weight": self.max_hidden_weight[0],
                 "virtual_params": model.layer_stacks.l1.factorized_linear.weight,
             },
             {
                 "params": [model.layer_stacks.l2.linear.weight],
-                "min_weight": -self.max_hidden_weight,
-                "max_weight": self.max_hidden_weight,
+                "min_weight": -self.max_hidden_weight[1],
+                "max_weight": self.max_hidden_weight[1],
             },
             {
                 "params": [model.layer_stacks.output.linear.weight],
-                "min_weight": -self.max_out_weight,
-                "max_weight": self.max_out_weight,
+                "min_weight": -self.max_hidden_weight[2],
+                "max_weight": self.max_hidden_weight[2],
             },
         ]
 
     def quantize_feature_transformer(
         self,
-        bias: torch.Tensor,
-        weight: torch.Tensor,
-        psqt_weight: torch.Tensor,
-        callback: Callable = lambda *args, **kwargs: None,
+        bias: Optional[torch.Tensor],
+        weight: Optional[torch.Tensor],
+        psqt_weight: Optional[torch.Tensor],
+        f_weight_export_dtype: torch.dtype = torch.int16,
+        callback: Optional[Callable] = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        bias = bias.mul(self.ft_quantized_one).round().to(torch.int16)
-        weight = weight.mul(self.ft_quantized_one).round().to(torch.int16)
-        psqt_weight = (
-            psqt_weight.mul(self.nnue2score * self.weight_scale_out)
-            .round()
-            .to(torch.int32)
-        )
+        if bias is not None:
+            # only weight can have different dtypes, bias is always int16, psqt_weight is always int32
+            bias = bias.mul(self.ft_quantized_one)
+            bias, bias_clipped = _safe_convert(bias, torch.int16)
 
-        callback(bias, weight, psqt_weight)
+            if callback is not None:
+                callback("ft_bias", bias, bias_clipped)
+
+        if weight is not None:
+            weight = weight.mul(self.ft_quantized_one)
+            weight, weight_clipped = _safe_convert(weight, f_weight_export_dtype)
+
+            if callback is not None:
+                callback("ft_weight", weight, weight_clipped)
+
+        if psqt_weight is not None:
+            psqt_weight = psqt_weight.mul(self.nnue2score * self.weight_scale_out)
+            psqt_weight, psqt_weight_clipped = _safe_convert(psqt_weight, torch.int32)
+
+            if callback is not None:
+                callback("psqt_weight", psqt_weight, psqt_weight_clipped)
 
         return bias, weight, psqt_weight
 
@@ -87,9 +142,9 @@ class QuantizationManager:
         weight: torch.Tensor,
         psqt_weight: torch.Tensor,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        bias = bias.divide(self.ft_quantized_one)
-        weight = weight.divide(self.ft_quantized_one)
-        psqt_weight = psqt_weight.divide(self.nnue2score * self.weight_scale_out)
+        bias = bias.divide(self.ft_quantized_one) if bias is not None else None
+        weight = weight.divide(self.ft_quantized_one) if weight is not None else None
+        psqt_weight = psqt_weight.divide(self.nnue2score * self.weight_scale_out) if psqt_weight is not None else None
 
         return bias, weight, psqt_weight
 
@@ -97,35 +152,18 @@ class QuantizationManager:
         self,
         bias: torch.Tensor,
         weight: torch.Tensor,
-        output_layer: bool = False,
-        callback: Callable = lambda *args, **kwargs: None,
+        layer_idx: int,
+        callback: Optional[Callable] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        kWeightScaleHidden = self.weight_scale_hidden
-        kWeightScaleOut = (
-            self.nnue2score * self.weight_scale_out / self.hidden_quantized_one
-        )
-        kWeightScale = kWeightScaleOut if output_layer else kWeightScaleHidden
-        kBiasScaleOut = self.weight_scale_out * self.nnue2score
-        kBiasScaleHidden = self.weight_scale_hidden * self.hidden_quantized_one
-        kBiasScale = kBiasScaleOut if output_layer else kBiasScaleHidden
-        kMaxWeight = self.hidden_quantized_one / kWeightScale
+        kBiasScaleHidden = self.weight_scale_hidden[layer_idx] * self.hidden_quantized_one
+        kWeightScaleHidden = self.weight_scale_hidden[layer_idx]
 
-        bias = bias.mul(kBiasScale).round().to(torch.int32)
+        bias, bias_clipped = _safe_convert(bias.mul(kBiasScaleHidden), torch.int32)
+        weight, weight_clipped = _safe_convert(weight.mul(kWeightScaleHidden), torch.int8)
 
-        clipped = torch.count_nonzero(weight.clamp(-kMaxWeight, kMaxWeight) - weight)
-        total_elements = torch.numel(weight)
-        clipped_max = torch.max(
-            torch.abs(weight.clamp(-kMaxWeight, kMaxWeight) - weight)
-        )
-
-        weight = (
-            weight.clamp(-kMaxWeight, kMaxWeight)
-            .mul(kWeightScale)
-            .round()
-            .to(torch.int8)
-        )
-
-        callback(bias, weight, clipped, total_elements, clipped_max, kMaxWeight)
+        if callback is not None:
+            callback("fc_weight", weight, weight_clipped)
+            callback("fc_bias", bias, bias_clipped)
 
         return bias, weight
 
@@ -133,18 +171,12 @@ class QuantizationManager:
         self,
         bias: torch.Tensor,
         weight: torch.Tensor,
-        output_layer: bool = False,
+        layer_idx: int,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        kWeightScaleHidden = self.weight_scale_hidden
-        kWeightScaleOut = (
-            self.nnue2score * self.weight_scale_out / self.hidden_quantized_one
-        )
-        kWeightScale = kWeightScaleOut if output_layer else kWeightScaleHidden
-        kBiasScaleOut = self.weight_scale_out * self.nnue2score
-        kBiasScaleHidden = self.weight_scale_hidden * self.hidden_quantized_one
-        kBiasScale = kBiasScaleOut if output_layer else kBiasScaleHidden
+        kBiasScaleHidden = self.weight_scale_hidden[layer_idx] * self.hidden_quantized_one
+        kWeightScaleHidden = self.weight_scale_hidden[layer_idx]
 
-        bias = bias.divide(kBiasScale)
-        weight = weight.divide(kWeightScale)
+        bias = bias.divide(kBiasScaleHidden)
+        weight = weight.divide(kWeightScaleHidden)
 
         return bias, weight

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -48,7 +48,7 @@ class QuantizationConfig:
     nnue2score: float = 600.0
     weight_scale_l1: float = 64.0 # TODO 128 is better empirically for this layer
     weight_scale_l2: float = 64.0
-    # weight_scale_out = (self.nnue2score * self.weight_scale_out) / self.hidden_quantized_one
+    # weight_scale_l_out = (self.nnue2score * self.weight_scale_out) / self.hidden_quantized_one
     weight_scale_l_out: float = (600.0 * 16) / 128 # TODO 128 is better empirically for this layer
     weight_scale_out: float = 16.0 # TODO do calculation conversion on inference side
     weight_quantized_max_hidden: float = 127.0 # i8 max
@@ -92,16 +92,24 @@ class QuantizationManager:
     def clip_ft_act(self, preact):
         return torch.clamp(preact, 0.0, self.max_ft_activation)
 
+    def clip_ls_act(self, preact):
+        return torch.clamp(preact, 0, self.max_hidden_activation)
+
     def fake_quantize_ft_act(self, preact):
         act_scale = self.config.ft_quantized_one
         return _fake_quantize(preact, act_scale)
 
-    def clip_ls_act(self, preact):
-        return torch.clamp(preact, 0, self.max_hidden_activation)
-
     def fake_quantize_ls_act(self, preact):
         act_scale = self.config.hidden_quantized_one
         return _fake_quantize(preact, act_scale)
+
+    def fake_quantize_skip_act(self, preact):
+        # (600 * OutputScale) / (127 * (1 << WeightScaleBits))
+        act_scale = 1 / (self.hidden_quantized_one * self.config.weight_scale_l1)
+        tmp_scale = self.nnue2score * self.weight_scale_out * self.hidden_quantized_one
+        out = preact * tmp_scale
+        out = _fake_quantize(preact, act_scale)
+        return out / tmp_scale
 
     def generate_weight_clipping_config(
         self, model: "NNUEModel"

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -28,7 +28,7 @@ def _safe_convert(value: torch.Tensor, target_dtype: torch.dtype):
 @dataclass
 class QuantizationConfig:
     nnue2score: float = 600.0
-    weight_scale_l1: float = 128.0 # TODO 128 is better empirically for this layer
+    weight_scale_l1: float = 64.0 # TODO 128 is better empirically for this layer
     weight_scale_l2: float = 64.0
     # weight_scale_out = (self.nnue2score * self.weight_scale_out) / self.hidden_quantized_one
     weight_scale_l_out: float = (600.0 * 16) / 128 # TODO 128 is better empirically for this layer

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -23,8 +23,13 @@ def _safe_convert(value: torch.Tensor, target_dtype: torch.dtype):
     clamped_value = rounded_value.clamp(min_val, max_val)
     num_clipped = (rounded_value != clamped_value).sum()
     quantized_value = clamped_value.to(target_dtype)
+    min = rounded_value.min().item()
+    if num_clipped > 0:
+        min = rounded_value.min().item()
+        max = rounded_value.max().item()
+        raise RuntimeError(f"Found {num_clipped} out of bounds values when converting to target dtype {target_dtype}. Min: {min}, max: {max}.")
 
-    return quantized_value, num_clipped
+    return quantized_value
 
 def _fake_quantize(value, act_scale):
     # Fake quantization with STE
@@ -131,24 +136,24 @@ class QuantizationManager:
         if bias is not None:
             # only weight can have different dtypes, bias is always int16, psqt_weight is always int32
             bias = bias.mul(self.ft_quantized_one)
-            bias, bias_clipped = _safe_convert(bias, torch.int16)
+            bias = _safe_convert(bias, torch.int16)
 
             if callback is not None:
-                callback("ft_bias", bias, bias_clipped)
+                callback("ft_bias", bias)
 
         if weight is not None:
             weight = weight.mul(self.ft_quantized_one)
-            weight, weight_clipped = _safe_convert(weight, f_weight_export_dtype)
+            weight = _safe_convert(weight, f_weight_export_dtype)
 
             if callback is not None:
-                callback("ft_weight", weight, weight_clipped)
+                callback("ft_weight", weight)
 
         if psqt_weight is not None:
             psqt_weight = psqt_weight.mul(self.nnue2score * self.weight_scale_out)
-            psqt_weight, psqt_weight_clipped = _safe_convert(psqt_weight, torch.int32)
+            psqt_weight = _safe_convert(psqt_weight, torch.int32)
 
             if callback is not None:
-                callback("psqt_weight", psqt_weight, psqt_weight_clipped)
+                callback("psqt_weight", psqt_weight)
 
         return bias, weight, psqt_weight
 
@@ -174,12 +179,12 @@ class QuantizationManager:
         kBiasScaleHidden = self.weight_scale_hidden[layer_idx] * self.hidden_quantized_one
         kWeightScaleHidden = self.weight_scale_hidden[layer_idx]
 
-        bias, bias_clipped = _safe_convert(bias.mul(kBiasScaleHidden), torch.int32)
-        weight, weight_clipped = _safe_convert(weight.mul(kWeightScaleHidden), torch.int8)
+        bias = _safe_convert(bias.mul(kBiasScaleHidden), torch.int32)
+        weight = _safe_convert(weight.mul(kWeightScaleHidden), torch.int8)
 
         if callback is not None:
-            callback("fc_weight", weight, weight_clipped)
-            callback("fc_bias", bias, bias_clipped)
+            callback("fc_weight", weight)
+            callback("fc_bias", bias)
 
         return bias, weight
 

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -6,6 +6,7 @@ import torch
 if TYPE_CHECKING:
     from .model import NNUEModel
 
+FAKE_QUANTIZE_EPS = 1e-5
 
 class WeightClippingConfig(TypedDict):
     params: list[torch.Tensor]
@@ -36,7 +37,7 @@ def _fake_quantize(value, act_scale):
     # Inference uses bitshift which is equivalent to rounding down (floor).
     # act_scale is in nnue-pytorch is `> 1`, inverted compared to normal literature.
     # will be slightly inaccurate unless all corrections factors are 1.0.
-    value_hard = ((value * act_scale).floor() / act_scale).detach()
+    value_hard = ((value * act_scale + FAKE_QUANTIZE_EPS).floor() / act_scale).detach()
     value_soft = value.detach()
     value = value_hard + (value - value_soft)
 

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -77,26 +77,10 @@ class QuantizationManager:
         self.min_threat_weight = -_i8.max / config.ft_quantized_one  # -127/256
         self.max_threat_weight = _i8.max / config.ft_quantized_one  # 127/256
 
-        self._l0_correction_factor = config.ft_quantized_one ** 2 / config.inference_l0_division_factor / self.hidden_quantized_one
-        self._sqr_crelu_correction_factor = config.hidden_quantized_one / config.inference_sqr_crelu_division_factor
-        self._max_ft_activation = config.ft_quantized_max / config.ft_quantized_one
-        self._max_hidden_activation = config.hidden_quantized_max / config.hidden_quantized_one
-
-    @property
-    def l0_correction_factor(self):
-        return self._l0_correction_factor
-
-    @property
-    def sqr_crelu_correction_factor(self):
-        return self._sqr_crelu_correction_factor
-
-    @property
-    def max_ft_activation(self):
-        return self._max_ft_activation
-
-    @property
-    def max_hidden_activation(self):
-        return self._max_hidden_activation
+        self.l0_correction_factor = config.ft_quantized_one ** 2 / config.inference_l0_division_factor / self.hidden_quantized_one
+        self.sqr_crelu_correction_factor = config.hidden_quantized_one / config.inference_sqr_crelu_division_factor
+        self.max_ft_activation = config.ft_quantized_max / config.ft_quantized_one
+        self.max_hidden_activation = config.hidden_quantized_max / config.hidden_quantized_one
 
     def clip_ft_act(self, preact):
         return torch.clamp(preact, 0.0, self.max_ft_activation)

--- a/model/quantize.py
+++ b/model/quantize.py
@@ -49,10 +49,10 @@ class QuantizationConfig:
     weight_scale_l1: float = 64.0 # TODO 128 is better empirically for this layer
     weight_scale_l2: float = 64.0
     # weight_scale_l_out = (self.nnue2score * self.weight_scale_out) / self.hidden_quantized_one
-    weight_scale_l_out: float = (600.0 * 16) / 128 # TODO 128 is better empirically for this layer
+    weight_scale_l_out: float = (600.0 * 16) / 127 # TODO 128 is better empirically for this layer
     weight_scale_out: float = 16.0 # TODO do calculation conversion on inference side
     weight_quantized_max_hidden: float = 127.0 # i8 max
-    ft_quantized_one: float = 255.0 # TODO 255 is easier and does not require any adjustment factor
+    ft_quantized_one: float = 255.0 # TODO 256 is easier and does not require any adjustment factor
     ft_quantized_max: float = 255.0 # limited to 255 for safe squaring within i16
     hidden_quantized_one: float = 127.0 # TODO 128 is easier and does not require any adjustment factor
     hidden_quantized_max: float = 127.0 # i8 max

--- a/model/utils/load_model.py
+++ b/model/utils/load_model.py
@@ -3,14 +3,11 @@ import torch
 from .serialize import NNUEReader
 from ..config import ModelConfig
 from ..model import NNUEModel
-from ..quantize import QuantizationConfig
-
 
 def load_model(
     filename: str,
     feature_name: str,
     config: ModelConfig,
-    quantize_config: QuantizationConfig,
 ) -> NNUEModel:
     if filename.endswith(".pt"):
         model = torch.load(filename, weights_only=False)
@@ -24,14 +21,13 @@ def load_model(
             filename,
             feature_name=feature_name,
             config=config,
-            quantize_config=quantize_config,
         )
         model.eval()
         return model.model
 
     elif filename.endswith(".nnue"):
         with open(filename, "rb") as f:
-            reader = NNUEReader(f, feature_name, config, quantize_config)
+            reader = NNUEReader(f, feature_name, config)
         return reader.model
 
     else:

--- a/model/utils/serialize.py
+++ b/model/utils/serialize.py
@@ -11,11 +11,16 @@ from torch import nn
 
 from ..config import ModelConfig
 from ..model import NNUEModel
-from ..quantize import QuantizationConfig, safe_convert
 
 
-def ascii_hist(name, x, bins=6):
-    N, X = np.histogram(x, bins=bins)
+def ascii_hist(name, x, bins=7):
+    start, end = int(x.min()), int(x.max())
+    if start >= end - bins:
+        start -= (bins + 1) // 2
+        end += bins // 2
+    edges = np.linspace(start, end + 1, bins + 1).astype(int)
+    edges = np.unique(edges)
+    N, X = np.histogram(x, bins=edges)
     width = 50
     nmax = N.max()
 
@@ -25,6 +30,37 @@ def ascii_hist(name, x, bins=6):
         xi = "{0: <8.4g}".format(xi).ljust(10)
         print("{0}| {1}".format(xi, bar))
 
+def get_histogram_callback(hist_title: str, verbose: bool):
+    if not verbose:
+        return None
+
+    def histogram_callback(
+        hist_subtitle: str,
+        values: torch.Tensor,
+        num_clipped: torch.Tensor,
+    ):
+        total_elements = values.numel()
+        hist_desc = [hist_title, hist_subtitle]
+        hist_desc = " ".join(filter(None, hist_desc))
+
+        if total_elements == 0:
+            print(f"Layer '{hist_desc}' is empty.")
+            return
+
+        num_clipped = int(num_clipped.sum().item())
+        min_value = values.min().item()
+        num_argmin = int((values == min_value).sum().item())
+        max_value = values.max().item()
+        num_argmax = int((values == max_value).sum().item())
+
+        ascii_hist(f"{hist_desc}: ", values.detach().cpu().numpy())
+        print(
+            f"Layer has {num_clipped}/{total_elements} clipped weights after rounding.\n"
+            f"Minimum value in layer is {min_value}, occurring {num_argmin} times.\n"
+            f"Maximum value in layer is {max_value}, occurring {num_argmax} times."
+        )
+
+    return histogram_callback
 
 @njit
 def encode_leb_128_array(arr: npt.NDArray) -> list:
@@ -73,21 +109,23 @@ class NNUEWriter:
         model: NNUEModel,
         description: str | None = None,
         ft_compression: str = "none",
+        verbose: bool = True,
     ):
         if description is None:
             description = DEFAULT_DESCRIPTION
 
         self.buf = bytearray()
+        self.verbose = verbose
 
         fc_hash = self.fc_hash(model)
         self.write_header(model, fc_hash, description)
         self.int32(model.feature_hash ^ (model.L1 * 2))  # Feature transformer hash
         self.write_feature_transformer(model, ft_compression)
-        for l1, l2, output in model.layer_stacks.get_coalesced_layer_stacks():
+        for bucket, (l1, l2, output) in enumerate(model.layer_stacks.get_coalesced_layer_stacks()):
             self.int32(fc_hash)  # FC layers hash
-            self.write_fc_layer(model, l1)
-            self.write_fc_layer(model, l2)
-            self.write_fc_layer(model, output, is_output=True)
+            self.write_fc_layer(model, l1, 0, f"bucket {bucket} l1")
+            self.write_fc_layer(model, l2, 1, f"bucket {bucket} l2")
+            self.write_fc_layer(model, output, 2, f"bucket {bucket} output")
 
     @staticmethod
     def fc_hash(model: NNUEModel) -> int:
@@ -124,7 +162,8 @@ class NNUEWriter:
         self.int32(len(buf))
         self.buf.extend(buf)
 
-    def write_tensor(self, arr: npt.NDArray, compression="none") -> None:
+    def write_tensor(self, arr: torch.Tensor, compression="none") -> None:
+        arr = arr.detach().flatten().cpu().numpy()
         if compression == "none":
             self.buf.extend(arr.tobytes())
         elif compression == "leb128":
@@ -143,56 +182,52 @@ class NNUEWriter:
         weight = export_weight[:, : model.L1]
         psqt_weight = export_weight[:, model.L1 :]
 
-        def histogram_callback(
-            bias: torch.Tensor, weight: torch.Tensor, psqt_weight: torch.Tensor
-        ):
-            ascii_hist("ft bias:", bias.numpy())
-            ascii_hist("ft weight:", weight.numpy())
-            ascii_hist("ft psqt weight:", psqt_weight.numpy())
-
-        bias, weight, psqt_weight = model.quantization.quantize_feature_transformer(
-            bias, weight, psqt_weight, histogram_callback
+        # biases are exported as i16s
+        biases, _, _ = model.quantization.quantize_feature_transformer(
+            bias, None, None, torch.int16, get_histogram_callback("", self.verbose)
         )
 
+        self.write_tensor(biases, ft_compression)
+
+        # TODO remove after adjustment
+        psqt_weights_to_write = []
+
         # Weights stored as [num_features][outputs]
-        self.write_tensor(bias.flatten().numpy(), ft_compression)
         offset = 0
         for f in layer.features:
             n = f.NUM_REAL_FEATURES
-            segment = weight[offset : offset + n]
-            if f.EXPORT_WEIGHT_DTYPE == torch.int8:
-                segment = safe_convert(segment, torch.int8)
-                self.write_tensor(segment.flatten().numpy())
-            else:
-                self.write_tensor(segment.flatten().numpy(), ft_compression)
+            f_export_dtype = f.EXPORT_WEIGHT_DTYPE
+
+            ft_histogram_callback = get_histogram_callback(f.FEATURE_NAME, self.verbose)
+            segment_weight = weight[offset : offset + n]
+            segment_psqt_weight = psqt_weight[offset : offset + n]
+            _, segment_weight, segment_psqt_weight = model.quantization.quantize_feature_transformer(
+                None, segment_weight, segment_psqt_weight, f_export_dtype, ft_histogram_callback
+            )
+            # threat weights are expected to always be uncompressed -- should be changed in the future
+            segment_compression = ft_compression if not f_export_dtype == torch.int8 else "none"
             offset += n
-        self.write_tensor(psqt_weight.flatten().numpy(), ft_compression)
+
+            # TODO Adjust layout on inference side for simplication
+            self.write_tensor(segment_weight, segment_compression)
+            psqt_weights_to_write.append(segment_psqt_weight)
+            # self.write_tensor(segment_psqt_weight, ft_compression)
+
+        self.write_tensor(torch.cat(psqt_weights_to_write, dim=0), ft_compression)
 
     def write_fc_layer(
-        self, model: NNUEModel, layer: nn.Linear, is_output=False
+        self,
+        model: NNUEModel,
+        layer: nn.Linear,
+        layer_idx: int,
+        desc: str,
     ) -> None:
         # FC layers are stored as int8 weights, and int32 biases
         bias = layer.bias.data
         weight = layer.weight.data
 
-        def histogram_callback(
-            bias: torch.Tensor,
-            weight: torch.Tensor,
-            clipped: torch.Tensor,
-            total_elements: int,
-            clipped_max: torch.Tensor,
-            kMaxWeight: float,
-        ):
-            ascii_hist("fc bias:", bias.numpy())
-            print(
-                "layer has {}/{} clipped weights. Exceeding by {} the maximum {}.".format(
-                    clipped, total_elements, clipped_max, kMaxWeight
-                )
-            )
-            ascii_hist("fc weight:", weight.numpy())
-
         bias, weight = model.quantization.quantize_fc_layer(
-            bias, weight, is_output, histogram_callback
+            bias, weight, layer_idx, get_histogram_callback(desc, self.verbose)
         )
 
         # FC inputs are padded to 32 elements by spec.
@@ -203,9 +238,9 @@ class NNUEWriter:
             new_w[:, : weight.shape[1]] = weight
             weight = new_w
 
-        self.buf.extend(bias.flatten().numpy().tobytes())
+        self.write_tensor(bias, "none")
         # Weights stored as [outputs][inputs], so we can flatten
-        self.buf.extend(weight.flatten().numpy().tobytes())
+        self.write_tensor(weight, "none")
 
     def int32(self, v: int) -> None:
         self.buf.extend(struct.pack("<I", v))
@@ -217,11 +252,10 @@ class NNUEReader:
         f: BinaryIO,
         feature_name: str,
         config: ModelConfig,
-        quantize_config: QuantizationConfig,
     ):
         self.f = f
         self.feature_name = feature_name
-        self.model = NNUEModel(feature_name, config, quantize_config)
+        self.model = NNUEModel(feature_name, config)
         self.config = config
         fc_hash = NNUEWriter.fc_hash(self.model)
 
@@ -252,7 +286,7 @@ class NNUEReader:
                 self.read_fc_layer(
                     l_w_slices[layer_idx][b],
                     l_b_slices[layer_idx][b],
-                    is_output=(layer_idx == len(layers) - 1),
+                    layer_idx,
                 )
 
     def read_header(self, feature_hash: int, fc_hash: int) -> None:
@@ -303,20 +337,25 @@ class NNUEReader:
             raise Exception("Invalid compression method.")
 
     def read_feature_transformer(self, layer, num_psqt_buckets: int) -> None:
-        num_export_features = layer.NUM_REAL_FEATURES
         num_outputs = layer.num_outputs
         L1 = num_outputs - num_psqt_buckets
 
         bias = self.tensor(np.int16, [L1])
         segments = []
+        # segments_psqt = []
 
         for feature in layer.features:
             dtype = np.int8 if feature.EXPORT_WEIGHT_DTYPE == torch.int8 else np.int16
             s = self.tensor(dtype, [feature.NUM_REAL_FEATURES, L1])
             segments.append(s)
+            # TODO simplify layout at inference side
+            # s_psqt = self.tensor(np.int32, [feature.NUM_REAL_FEATURES, num_psqt_buckets])
+            # segments_psqt.append(s_psqt)
 
         weight = torch.cat(segments, dim=0)
-        psqt_weight = self.tensor(np.int32, [num_export_features, num_psqt_buckets])
+        # TODO simplify layout at inference side
+        # psqt_weight = torch.cat(segments_psqt, dim=0)
+        psqt_weight = self.tensor(np.int32, [layer.NUM_REAL_FEATURES, num_psqt_buckets])
 
         bias, weight, psqt_weight = (
             self.model.quantization.dequantize_feature_transformer(
@@ -333,7 +372,7 @@ class NNUEReader:
         self,
         layer_weight_t: torch.Tensor,
         layer_bias_t: torch.Tensor,
-        is_output: bool = False,
+        layer_idx: int,
     ) -> None:
         # FC inputs are padded to 32 elements by spec.
         non_padded_shape = layer_weight_t.shape
@@ -343,7 +382,7 @@ class NNUEReader:
         weight = self.tensor(np.int8, padded_shape)
 
         bias, weight = self.model.quantization.dequantize_fc_layer(
-            bias, weight, is_output
+            bias, weight, layer_idx
         )
 
         layer_bias = bias

--- a/model/utils/serialize.py
+++ b/model/utils/serialize.py
@@ -11,11 +11,16 @@ from torch import nn
 
 from ..config import ModelConfig
 from ..model import NNUEModel
-from ..quantize import QuantizationConfig
 
 
-def ascii_hist(name, x, bins=6):
-    N, X = np.histogram(x, bins=bins)
+def ascii_hist(name, x, bins=7):
+    start, end = int(x.min()), int(x.max())
+    if start >= end - bins:
+        start -= (bins + 1) // 2
+        end += bins // 2
+    edges = np.linspace(start, end + 1, bins + 1).astype(int)
+    edges = np.unique(edges)
+    N, X = np.histogram(x, bins=edges)
     width = 50
     nmax = N.max()
 
@@ -25,6 +30,37 @@ def ascii_hist(name, x, bins=6):
         xi = "{0: <8.4g}".format(xi).ljust(10)
         print("{0}| {1}".format(xi, bar))
 
+def get_histogram_callback(hist_title: str, verbose: bool):
+    if not verbose:
+        return None
+
+    def histogram_callback(
+        hist_subtitle: str,
+        values: torch.Tensor,
+        num_clipped: torch.Tensor,
+    ):
+        total_elements = values.numel()
+        hist_desc = [hist_title, hist_subtitle]
+        hist_desc = " ".join(filter(None, hist_desc))
+
+        if total_elements == 0:
+            print(f"Layer '{hist_desc}' is empty.")
+            return
+
+        num_clipped = int(num_clipped.sum().item())
+        min_value = values.min().item()
+        num_argmin = int((values == min_value).sum().item())
+        max_value = values.max().item()
+        num_argmax = int((values == max_value).sum().item())
+
+        ascii_hist(f"{hist_desc}: ", values.numpy())
+        print(
+            f"Layer has {num_clipped}/{total_elements} clipped weights after rounding.\n"
+            f"Minimum absval in layer is {min_value}, occurring {num_argmin} times.\n"
+            f"Maximum absval in layer is {max_value}, occurring {num_argmax} times."
+        )
+
+    return histogram_callback
 
 @njit
 def encode_leb_128_array(arr: npt.NDArray) -> list:
@@ -59,7 +95,7 @@ def decode_leb_128_array(arr: bytes, n: int) -> npt.NDArray:
 
 
 # hardcoded for now
-VERSION = 0x7AF32F20
+VERSION = 0x6A448AFA
 DEFAULT_DESCRIPTION = "Network trained with the https://github.com/official-stockfish/nnue-pytorch trainer."
 
 
@@ -73,21 +109,31 @@ class NNUEWriter:
         model: NNUEModel,
         description: str | None = None,
         ft_compression: str = "none",
+        verbose: bool = True,
     ):
         if description is None:
             description = DEFAULT_DESCRIPTION
 
         self.buf = bytearray()
+        self.verbose = verbose
+
+        # it is the safest to call clip weights before exporting
+        # some weights might be clipped to smaller values than dtype.max
+        # (threat weights in particular)
+        # This does change the model weights in place,
+        # since it is supposed to be called after every training step anyway, this is fine
+        model.clip_weights()
+        model.clip_input_weights()
 
         fc_hash = self.fc_hash(model)
         self.write_header(model, fc_hash, description)
         self.int32(model.feature_hash ^ (model.L1 * 2))  # Feature transformer hash
         self.write_feature_transformer(model, ft_compression)
-        for l1, l2, output in model.layer_stacks.get_coalesced_layer_stacks():
+        for bucket, (l1, l2, output) in enumerate(model.layer_stacks.get_coalesced_layer_stacks()):
             self.int32(fc_hash)  # FC layers hash
-            self.write_fc_layer(model, l1)
-            self.write_fc_layer(model, l2)
-            self.write_fc_layer(model, output, is_output=True)
+            self.write_fc_layer(model, l1, 0, f"bucket {bucket} l1")
+            self.write_fc_layer(model, l2, 1, f"bucket {bucket} l2")
+            self.write_fc_layer(model, output, 2, f"bucket {bucket} output")
 
     @staticmethod
     def fc_hash(model: NNUEModel) -> int:
@@ -143,55 +189,45 @@ class NNUEWriter:
         weight = export_weight[:, : model.L1]
         psqt_weight = export_weight[:, model.L1 :]
 
-        def histogram_callback(
-            bias: torch.Tensor, weight: torch.Tensor, psqt_weight: torch.Tensor
-        ):
-            ascii_hist("ft bias:", bias.numpy())
-            ascii_hist("ft weight:", weight.numpy())
-            ascii_hist("ft psqt weight:", psqt_weight.numpy())
-
-        bias, weight, psqt_weight = model.quantization.quantize_feature_transformer(
-            bias, weight, psqt_weight, histogram_callback
+        # biases are exported as i16s
+        biases, _, _ = model.quantization.quantize_feature_transformer(
+            bias, None, None, torch.int16, get_histogram_callback("", self.verbose)
         )
 
+        self.write_tensor(biases.flatten().numpy(), ft_compression)
+
         # Weights stored as [num_features][outputs]
-        self.write_tensor(bias.flatten().numpy(), ft_compression)
         offset = 0
         for f in layer.features:
             n = f.NUM_REAL_FEATURES
-            segment = weight[offset : offset + n]
-            if f.EXPORT_WEIGHT_DTYPE == torch.int8:
-                self.write_tensor(segment.to(torch.int8).flatten().numpy())
-            else:
-                self.write_tensor(segment.flatten().numpy(), ft_compression)
+            f_export_dtype = f.EXPORT_WEIGHT_DTYPE
+
+            ft_histogram_callback = get_histogram_callback(f.FEATURE_NAME, self.verbose)
+            segment_weight = weight[offset : offset + n]
+            segment_psqt_weight = psqt_weight[offset : offset + n]
+            _, segment_weight, segment_psqt_weight = model.quantization.quantize_feature_transformer(
+                None, segment_weight, segment_psqt_weight, f_export_dtype, ft_histogram_callback
+            )
+            # threat weights are expected to always be uncompressed -- should be changed in the future
+            segment_compression = ft_compression if not f_export_dtype == torch.int8 else "none"
             offset += n
-        self.write_tensor(psqt_weight.flatten().numpy(), ft_compression)
+
+            self.write_tensor(segment_weight.flatten().numpy(), segment_compression)
+            self.write_tensor(segment_psqt_weight.flatten().numpy(), ft_compression)
 
     def write_fc_layer(
-        self, model: NNUEModel, layer: nn.Linear, is_output=False
+        self,
+        model: NNUEModel,
+        layer: nn.Linear,
+        layer_idx: int,
+        desc: str,
     ) -> None:
         # FC layers are stored as int8 weights, and int32 biases
         bias = layer.bias.data
         weight = layer.weight.data
 
-        def histogram_callback(
-            bias: torch.Tensor,
-            weight: torch.Tensor,
-            clipped: torch.Tensor,
-            total_elements: int,
-            clipped_max: torch.Tensor,
-            kMaxWeight: float,
-        ):
-            ascii_hist("fc bias:", bias.numpy())
-            print(
-                "layer has {}/{} clipped weights. Exceeding by {} the maximum {}.".format(
-                    clipped, total_elements, clipped_max, kMaxWeight
-                )
-            )
-            ascii_hist("fc weight:", weight.numpy())
-
         bias, weight = model.quantization.quantize_fc_layer(
-            bias, weight, is_output, histogram_callback
+            bias, weight, layer_idx, get_histogram_callback(desc, self.verbose)
         )
 
         # FC inputs are padded to 32 elements by spec.
@@ -216,11 +252,10 @@ class NNUEReader:
         f: BinaryIO,
         feature_name: str,
         config: ModelConfig,
-        quantize_config: QuantizationConfig,
     ):
         self.f = f
         self.feature_name = feature_name
-        self.model = NNUEModel(feature_name, config, quantize_config)
+        self.model = NNUEModel(feature_name, config)
         self.config = config
         fc_hash = NNUEWriter.fc_hash(self.model)
 
@@ -251,7 +286,7 @@ class NNUEReader:
                 self.read_fc_layer(
                     l_w_slices[layer_idx][b],
                     l_b_slices[layer_idx][b],
-                    is_output=(layer_idx == len(layers) - 1),
+                    layer_idx,
                 )
 
     def read_header(self, feature_hash: int, fc_hash: int) -> None:
@@ -302,20 +337,22 @@ class NNUEReader:
             raise Exception("Invalid compression method.")
 
     def read_feature_transformer(self, layer, num_psqt_buckets: int) -> None:
-        num_export_features = layer.NUM_REAL_FEATURES
         num_outputs = layer.num_outputs
         L1 = num_outputs - num_psqt_buckets
 
         bias = self.tensor(np.int16, [L1])
         segments = []
+        segments_psqt = []
 
         for feature in layer.features:
             dtype = np.int8 if feature.EXPORT_WEIGHT_DTYPE == torch.int8 else np.int16
             s = self.tensor(dtype, [feature.NUM_REAL_FEATURES, L1])
+            s_psqt = self.tensor(np.int32, [feature.NUM_REAL_FEATURES, num_psqt_buckets])
             segments.append(s)
+            segments_psqt.append(s_psqt)
 
         weight = torch.cat(segments, dim=0)
-        psqt_weight = self.tensor(np.int32, [num_export_features, num_psqt_buckets])
+        psqt_weight = torch.cat(segments_psqt, dim=0)
 
         bias, weight, psqt_weight = (
             self.model.quantization.dequantize_feature_transformer(
@@ -332,7 +369,7 @@ class NNUEReader:
         self,
         layer_weight_t: torch.Tensor,
         layer_bias_t: torch.Tensor,
-        is_output: bool = False,
+        layer_idx: int,
     ) -> None:
         # FC inputs are padded to 32 elements by spec.
         non_padded_shape = layer_weight_t.shape
@@ -342,7 +379,7 @@ class NNUEReader:
         weight = self.tensor(np.int8, padded_shape)
 
         bias, weight = self.model.quantization.dequantize_fc_layer(
-            bias, weight, is_output
+            bias, weight, layer_idx
         )
 
         layer_bias = bias

--- a/model/utils/serialize.py
+++ b/model/utils/serialize.py
@@ -37,7 +37,6 @@ def get_histogram_callback(hist_title: str, verbose: bool):
     def histogram_callback(
         hist_subtitle: str,
         values: torch.Tensor,
-        num_clipped: torch.Tensor,
     ):
         total_elements = values.numel()
         hist_desc = [hist_title, hist_subtitle]
@@ -47,7 +46,6 @@ def get_histogram_callback(hist_title: str, verbose: bool):
             print(f"Layer '{hist_desc}' is empty.")
             return
 
-        num_clipped = int(num_clipped.sum().item())
         min_value = values.min().item()
         num_argmin = int((values == min_value).sum().item())
         max_value = values.max().item()
@@ -55,7 +53,6 @@ def get_histogram_callback(hist_title: str, verbose: bool):
 
         ascii_hist(f"{hist_desc}: ", values.detach().cpu().numpy())
         print(
-            f"Layer has {num_clipped}/{total_elements} clipped weights after rounding.\n"
             f"Minimum value in layer is {min_value}, occurring {num_argmin} times.\n"
             f"Maximum value in layer is {max_value}, occurring {num_argmax} times."
         )

--- a/model/utils/serialize.py
+++ b/model/utils/serialize.py
@@ -53,11 +53,11 @@ def get_histogram_callback(hist_title: str, verbose: bool):
         max_value = values.max().item()
         num_argmax = int((values == max_value).sum().item())
 
-        ascii_hist(f"{hist_desc}: ", values.numpy())
+        ascii_hist(f"{hist_desc}: ", values.detach().cpu().numpy())
         print(
             f"Layer has {num_clipped}/{total_elements} clipped weights after rounding.\n"
-            f"Minimum absval in layer is {min_value}, occurring {num_argmin} times.\n"
-            f"Maximum absval in layer is {max_value}, occurring {num_argmax} times."
+            f"Minimum value in layer is {min_value}, occurring {num_argmin} times.\n"
+            f"Maximum value in layer is {max_value}, occurring {num_argmax} times."
         )
 
     return histogram_callback
@@ -170,7 +170,8 @@ class NNUEWriter:
         self.int32(len(buf))
         self.buf.extend(buf)
 
-    def write_tensor(self, arr: npt.NDArray, compression="none") -> None:
+    def write_tensor(self, arr: torch.Tensor, compression="none") -> None:
+        arr = arr.detach().flatten().cpu().numpy()
         if compression == "none":
             self.buf.extend(arr.tobytes())
         elif compression == "leb128":
@@ -194,7 +195,7 @@ class NNUEWriter:
             bias, None, None, torch.int16, get_histogram_callback("", self.verbose)
         )
 
-        self.write_tensor(biases.flatten().numpy(), ft_compression)
+        self.write_tensor(biases, ft_compression)
 
         # Weights stored as [num_features][outputs]
         offset = 0
@@ -212,8 +213,8 @@ class NNUEWriter:
             segment_compression = ft_compression if not f_export_dtype == torch.int8 else "none"
             offset += n
 
-            self.write_tensor(segment_weight.flatten().numpy(), segment_compression)
-            self.write_tensor(segment_psqt_weight.flatten().numpy(), ft_compression)
+            self.write_tensor(segment_weight, segment_compression)
+            self.write_tensor(segment_psqt_weight, ft_compression)
 
     def write_fc_layer(
         self,
@@ -238,9 +239,9 @@ class NNUEWriter:
             new_w[:, : weight.shape[1]] = weight
             weight = new_w
 
-        self.buf.extend(bias.flatten().numpy().tobytes())
+        self.write_tensor(bias, "none")
         # Weights stored as [outputs][inputs], so we can flatten
-        self.buf.extend(weight.flatten().numpy().tobytes())
+        self.write_tensor(weight, "none")
 
     def int32(self, v: int) -> None:
         self.buf.extend(struct.pack("<I", v))

--- a/serialize.py
+++ b/serialize.py
@@ -79,7 +79,6 @@ def main():
         nnue = M.NNUE.load_from_checkpoint(
             args.source,
             config=nnue_lightning_config,
-            quantize_config=M.QuantizationConfig(),
             map_location=torch.device("cpu"),
         )
         nnue.eval()
@@ -89,13 +88,11 @@ def main():
         with open(args.source, "rb") as f:
             nnue = M.NNUE(
                 config=nnue_lightning_config,
-                quantize_config=M.QuantizationConfig(),
             )
             reader = M.NNUEReader(
                 f,
                 feature_name,
                 config=nnue_lightning_config.model_config,
-                quantize_config=M.QuantizationConfig(),
             )
             nnue.model = reader.model
             if serialize_config.description is None:

--- a/serialize.py
+++ b/serialize.py
@@ -92,7 +92,6 @@ def main():
         nnue = M.NNUE.load_from_checkpoint(
             args.source,
             config=nnue_lightning_config,
-            quantize_config=M.QuantizationConfig(),
             map_location=torch.device("cpu"),
         )
         nnue.eval()
@@ -102,13 +101,11 @@ def main():
         with open(args.source, "rb") as f:
             nnue = M.NNUE(
                 config=nnue_lightning_config,
-                quantize_config=M.QuantizationConfig(),
             )
             reader = M.NNUEReader(
                 f,
                 feature_name,
                 config=nnue_lightning_config.model_config,
-                quantize_config=M.QuantizationConfig(),
             )
             nnue.model = reader.model
             if serialize_config.description is None:

--- a/train.py
+++ b/train.py
@@ -328,7 +328,6 @@ def main():
             max_epoch=max_epoch,
             num_batches_per_epoch=args.num_batches_per_epoch,
             param_index=args.dataloader_config.param_index,
-            quantize_config=M.QuantizationConfig(),
         )
     else:
         assert os.path.exists(args.resume_from_model)

--- a/train.py
+++ b/train.py
@@ -368,7 +368,6 @@ def main():
             max_epoch=max_epoch,
             num_batches_per_epoch=args.num_batches_per_epoch,
             param_index=args.dataloader_config.param_index,
-            quantize_config=M.QuantizationConfig(),
         )
     else:
         assert os.path.exists(args.resume_from_model)

--- a/visualize.py
+++ b/visualize.py
@@ -664,7 +664,6 @@ def main():
         args.model,
         feature_name,
         M.ModelConfig.get_model_config(args),
-        M.QuantizationConfig(),
     )
 
     if args.ref_model:
@@ -674,7 +673,6 @@ def main():
             args.ref_model,
             ref_feature_name,
             M.ModelConfig.get_model_config(args),
-            M.QuantizationConfig(),
         )
 
         print(

--- a/visualize_multi_hist.py
+++ b/visualize_multi_hist.py
@@ -88,7 +88,6 @@ def main():
             m,
             feature_name,
             config,
-            M.QuantizationConfig(),
         )
         for m in args.models
     ]


### PR DESCRIPTION
Improves quant config and removes hard coded values from the code.

The main goal is to improve readability and maintainability. As of currently there is a mismatch between training and inference (see #416 for more information). This patch intends to not only fix the mismatch but also to prevent mismatches in the future by inferring runtime correction factors directly from the quantization config instead of relying on manual changes across the codebase.

This allows arbitrary changes to the weight and activation quantization scales without having to make changes across the entire codebase.

As a quality of life improvement, serialize.py and quantize.py were refactored and the information density of the histogram callback was improved: The current histogram callback reports three values that are rather uninformative, since the model weights are already clipped through the callbacks. The logic was changed to use the native clipping of the model first and then clip only for type safety for serialization.

Allows more fine grained control over quant scheme (i.e. different weight scales per ls layer) and automatically calculates required adjustment factors to match inference instead of relying on hardcoding

Keeps quant scheme as is with TODO comments for possible further improve. In particular empirical observations show that slightly different quant scales probably preferred.

ADDED FUNCTIONALITY:
- fake quantization of activations 

~~Output scale is handled by https://github.com/TonyCongqianWang/Stockfish/blob/384175653285f68b67bd6a8d696380c40731e8c8/src/nnue/nnue_architecture.h#L135 which should yield slightly higher resolution. The main advantage however is better maintainability.~~

~~The maximum number of fully saturated inputs to i32 with i8*i8 inputs would be `133,144 / (600 * OutputScale) = 13` There is actually some risk of overflow even with the current setup, as even L3 has enough neurons and L1 has a skip connection. However given that L1=8k worked, this should be fine. But as a safety measure I will change the order of operation so that the maximum number of fully saturated neurons becomes `133,144 / (600 * OutputScale / WeightScale) = 887`~~