### PR TITLE
skip zero evals

### DIFF
--- a/data_loader/cpp/training_data_loader.cpp
+++ b/data_loader/cpp/training_data_loader.cpp
@@ -659,7 +659,6 @@ std::function<bool(const TrainingDataEntry&)> make_skip_predicate(DataloaderSkip
 
             auto do_filter = [&]() { return (e.isCapturingMove() || e.isInCheck()); };
 
-            if (e.score == 0) return true;
             if (e.score == VALUE_NONE) return true;
             if (e.ply <= config.early_fen_skipping) return true;
             if (config.random_fen_skipping && do_skip()) return true;

--- a/data_loader/cpp/training_data_loader.cpp
+++ b/data_loader/cpp/training_data_loader.cpp
@@ -642,6 +642,8 @@ std::function<bool(const TrainingDataEntry&)> make_skip_predicate(DataloaderSkip
             static thread_local double piece_count_history_passed[33]   = {0};
             static thread_local double piece_count_history_all_total    = 0;
             static thread_local double piece_count_history_passed_total = 0;
+            static thread_local bool   has_last_score                   = false;
+            static thread_local int    last_score                       = VALUE_NONE;
 
             static constexpr double max_skipping_rate = 10.0;
 
@@ -659,7 +661,17 @@ std::function<bool(const TrainingDataEntry&)> make_skip_predicate(DataloaderSkip
 
             auto do_filter = [&]() { return (e.isCapturingMove() || e.isInCheck()); };
 
+            const bool skip_zero_after_large_previous =
+              e.score == 0 && has_last_score && std::abs(last_score) > 100;
+
+            if (e.score != VALUE_NONE)
+            {
+                last_score     = e.score;
+                has_last_score = true;
+            }
+
             if (e.score == VALUE_NONE) return true;
+            if (skip_zero_after_large_previous) return true;
             if (e.ply <= config.early_fen_skipping) return true;
             if (config.random_fen_skipping && do_skip()) return true;
             if (config.filtered && do_filter()) return true;

--- a/data_loader/cpp/training_data_loader.cpp
+++ b/data_loader/cpp/training_data_loader.cpp
@@ -659,6 +659,7 @@ std::function<bool(const TrainingDataEntry&)> make_skip_predicate(DataloaderSkip
 
             auto do_filter = [&]() { return (e.isCapturingMove() || e.isInCheck()); };
 
+            if (e.score == 0) return true;
             if (e.score == VALUE_NONE) return true;
             if (e.ply <= config.early_fen_skipping) return true;
             if (config.random_fen_skipping && do_skip()) return true;


### PR DESCRIPTION
Trained with the following yaml definition https://github.com/Disservin/nettest/blob/8da0a21503adb341bc89ca20b4e2f166c7c9720d/threats.yaml

and the following trainer change 
https://github.com/official-stockfish/nnue-pytorch/commit/d87c248fbed584d08df59820ae0dd309e9b35c85

Initially I saw a lot of weird 0 scores in the binpack, since then @linrock has explained to me/us their meaning and mentioned that they are actually mostly skipped.. except a very small percentage, however it seems this change was still beneficial.

https://github.com/official-stockfish/Stockfish/pull/6730