### PR TITLE
Fix clang PGO dataloader builds

### DIFF
--- a/compile_data_loader.sh
+++ b/compile_data_loader.sh
@@ -40,6 +40,18 @@ cmake --build "$BUILD_DIR" -j
 echo "Running bench to generate profile data (pgo_run)..."
 cmake --build "$BUILD_DIR" --target pgo_run -j
 
+# Clang generates .profraw files that must be merged into
+# default.profdata before -fprofile-use can use it.
+if ls "$PGO_DIR"/*.profraw 1>/dev/null 2>&1; then
+  echo "Merging Clang raw profiles..."
+  if command -v xcrun >/dev/null 2>&1; then
+    xcrun llvm-profdata merge -output="$PGO_DIR/default.profdata" "$PGO_DIR"/*.profraw
+  else
+    echo "Error: llvm-profdata not found. Can't merge Clang profiles." >&2
+    exit 1
+  fi
+fi
+
 echo "Re-configuring for PGO_Use (use collected profiles)..."
 cmake -S "$SRC_DIR" -B "$BUILD_DIR" \
   -DCMAKE_BUILD_TYPE=PGO_Use \

--- a/data_loader/cpp/CMakeLists.txt
+++ b/data_loader/cpp/CMakeLists.txt
@@ -182,8 +182,11 @@ if(UPPER_BUILD_TYPE STREQUAL "PGO_GENERATE")
     -fprofile-generate=${PGO_PROFILE_DATA_DIR})
 
 elseif(UPPER_BUILD_TYPE MATCHES "^PGO_USE$")
-  target_compile_options(training_data_loader PRIVATE
-    -fprofile-use=${PGO_PROFILE_DATA_DIR} -fprofile-correction)
-  target_link_options(training_data_loader PRIVATE
-    -fprofile-use=${PGO_PROFILE_DATA_DIR} -fprofile-correction)
+  set(PGO_USE_FLAGS -fprofile-use=${PGO_PROFILE_DATA_DIR})
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    list(APPEND PGO_USE_FLAGS -fprofile-correction)
+  endif()
+
+  target_compile_options(training_data_loader PRIVATE ${PGO_USE_FLAGS})
+  target_link_options(training_data_loader PRIVATE ${PGO_USE_FLAGS})
 endif()


### PR DESCRIPTION
Gets dataloader compilation working with clang++ by fixing these:
```
clang++: error: Error in reading profile pgo_data/default.profdata: No such file or directory
clang++: warning: optimization flag '-fprofile-correction' is not supported [-Wignored-optimization-argument]
```