### PR TITLE
Decouple sparse linear function from CUDA

### DIFF
--- a/config.py
+++ b/config.py
@@ -50,6 +50,9 @@ class TrainingConfig:
     threads: int = -1
     """Number of torch threads to use. Default automatic (cores)."""
 
+    accelerator: Literal["auto", "cuda", "mps", "cpu"] = "auto"
+    """Hardware accelerator. 'auto' picks cuda > mps > cpu in order of availability."""
+
     compile_backend: Literal["inductor", "cudagraphs"] = "inductor"
     """Which backend to use for torch.compile. inductor works well with larger nets, cudagraphs with smaller nets."""
 

--- a/config.py
+++ b/config.py
@@ -27,7 +27,7 @@ class TrainingConfig:
     """Default root directory for logs and checkpoints. Default: None (use current directory)."""
 
     gpus: Optional[str] = None
-    """List of gpus to use, e.g. 0,1,2,3 for 4 gpus. Default: None (Use device 0 only)."""
+    """List of gpus to use, e.g. 0,1,2,3 for 4 gpus. Only used when accelerator="cuda"."""
 
     pin_memory: bool = True
     """Whether to use pin memory in the data pipeline. Should generally be left on unless you encounter issues with too much RAM usage."""

--- a/model/modules/feature_transformer/functions.py
+++ b/model/modules/feature_transformer/functions.py
@@ -9,7 +9,7 @@ try:
         make_sparse_input_linear_backward_kernel,
     )
     _HAS_CUPY_KERNELS = True
-except ImportError:
+except (ImportError, OSError, RuntimeError):
     pass
 
 

--- a/model/modules/feature_transformer/functions.py
+++ b/model/modules/feature_transformer/functions.py
@@ -1,13 +1,46 @@
 import torch
+import torch.nn.functional as F
 from torch import autograd
 
-from .kernel import (
-    make_sparse_input_linear_forward_kernel,
-    make_sparse_input_linear_backward_kernel,
-)
+_HAS_CUPY_KERNELS = False
+try:
+    from .kernel import (
+        make_sparse_input_linear_forward_kernel,
+        make_sparse_input_linear_backward_kernel,
+    )
+    _HAS_CUPY_KERNELS = True
+except ImportError:
+    pass
 
 
-class SparseLinearFunction(autograd.Function):
+def _torch_sparse_linear(feature_indices, feature_values, weight, bias):
+    """Device-agnostic fallback for SparseLinearFunction.
+
+    Computes: output[b] = sum_k(weight[indices[b,k]] * values[b,k]) + bias
+    Negative entries in feature_indices are treated as padding and
+    contribute nothing to the sum. Uses F.embedding_bag for memory efficiency.
+    """
+    batch_size, max_active = feature_indices.shape
+    mask = feature_indices >= 0
+    safe_indices = feature_indices.clamp(min=0).long().reshape(-1)
+    per_sample_weights = (feature_values * mask).reshape(-1)
+    offsets = torch.arange(
+        0,
+        batch_size * max_active,
+        max_active,
+        device=feature_indices.device,
+    )
+    output = F.embedding_bag(
+        safe_indices,
+        weight,
+        offsets,
+        mode="sum",
+        per_sample_weights=per_sample_weights,
+    )
+    return output + bias
+
+
+class _CudaSparseLinearFunction(autograd.Function):
     @staticmethod
     def forward(ctx, feature_indices, feature_values, weight, bias):
         ctx.save_for_backward(feature_indices, feature_values, weight, bias)
@@ -102,3 +135,17 @@ class SparseLinearFunction(autograd.Function):
         )
 
         return None, None, weight_grad, bias_grad
+
+
+class SparseLinearFunction:
+    """
+    Uses custom CuPy CUDA kernel when available. Otherwise falls back to a
+    PyTorch implementation that works on any device (CPU, MPS).
+    """
+    @staticmethod
+    def apply(feature_indices, feature_values, weight, bias):
+        if _HAS_CUPY_KERNELS and feature_indices.is_cuda:
+            return _CudaSparseLinearFunction.apply(
+                feature_indices, feature_values, weight, bias
+            )
+        return _torch_sparse_linear(feature_indices, feature_values, weight, bias)

--- a/tests/test_feature_transformer.py
+++ b/tests/test_feature_transformer.py
@@ -2,6 +2,7 @@ import os
 import sys
 import time
 
+import pytest
 import torch
 
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -28,12 +29,14 @@ def SparseLinearFunctionEmulate(
         for j in range(max_active_indices):
             feature = input_indices[i, j]
             value = input_values[i, j]
+            if feature < 0:
+                continue
             inputs[i, feature] += value
 
     return torch.mm(inputs, weight) + bias
 
 
-def test():
+def _run_test(device: torch.device):
     BATCH_SIZE = 16
     INPUT_SIZE = 10
     MAX_ACTIVE_FEATURES = 32
@@ -62,10 +65,16 @@ def test():
         indices1.clone(), values1.clone(), weight0, bias0
     )
     output10 = SparseLinearFunction.apply(
-        indices0.clone().cuda(), values0.clone().cuda(), weight1.cuda(), bias1.cuda()
+        indices0.clone().to(device),
+        values0.clone().to(device),
+        weight1.to(device),
+        bias1.to(device),
     )
     output11 = SparseLinearFunction.apply(
-        indices1.clone().cuda(), values1.clone().cuda(), weight1.cuda(), bias1.cuda()
+        indices1.clone().to(device),
+        values1.clone().to(device),
+        weight1.to(device),
+        bias1.to(device),
     )
 
     assert torch.max(torch.abs(output00.cpu() - output10.cpu())) < MAX_ERROR
@@ -74,7 +83,66 @@ def test():
     (output10 - output11).sum().backward()
     assert torch.max(torch.abs(weight0.grad.cpu() - weight1.grad.cpu())) < MAX_ERROR
     assert torch.max(torch.abs(bias0.grad.cpu() - bias1.grad.cpu())) < MAX_ERROR
-    print("Tests passed.")
+    print(f"Test passed on {device}.")
+
+
+def _run_padding_test(device: torch.device):
+    """Negative entries in feature_indices must be treated as padding."""
+    BATCH_SIZE = 8
+    INPUT_SIZE = 10
+    N_ACTIVE = 5
+    N_PADDING = 3
+    STRIDE = 64
+    MAX_ERROR = 1e-4
+
+    torch.manual_seed(42)
+    weight = torch.rand(INPUT_SIZE, STRIDE, dtype=torch.float32, device=device)
+    bias = torch.rand(STRIDE, dtype=torch.float32, device=device)
+
+    active_indices = (torch.rand(BATCH_SIZE, N_ACTIVE) * INPUT_SIZE).to(
+        dtype=torch.int32, device=device
+    )
+    active_values = torch.rand(
+        BATCH_SIZE, N_ACTIVE, dtype=torch.float32, device=device
+    )
+    padding_indices = torch.full(
+        (BATCH_SIZE, N_PADDING), -1, dtype=torch.int32, device=device
+    )
+    # Non-zero values in padding slots must not affect the output.
+    padding_values = torch.rand(
+        BATCH_SIZE, N_PADDING, dtype=torch.float32, device=device
+    )
+
+    out_unpadded = SparseLinearFunction.apply(
+        active_indices, active_values, weight, bias
+    )
+    indices_padded = torch.cat([active_indices, padding_indices], dim=1)
+    values_padded = torch.cat([active_values, padding_values], dim=1)
+    out_padded = SparseLinearFunction.apply(
+        indices_padded, values_padded, weight, bias
+    )
+
+    assert torch.max(torch.abs(out_unpadded - out_padded)) < MAX_ERROR
+    print(f"Padding test passed on {device}.")
+
+
+def test_cpu():
+    _run_test(torch.device("cpu"))
+    _run_padding_test(torch.device("cpu"))
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_cuda():
+    _run_test(torch.device("cuda"))
+    _run_padding_test(torch.device("cuda"))
+
+
+@pytest.mark.skipif(
+    not torch.backends.mps.is_available(), reason="MPS not available"
+)
+def test_mps():
+    _run_test(torch.device("mps"))
+    _run_padding_test(torch.device("mps"))
 
 
 def bench():
@@ -122,5 +190,13 @@ def bench():
 
 
 if __name__ == "__main__":
-    test()
-    bench()
+    _run_test(torch.device("cpu"))
+    _run_padding_test(torch.device("cpu"))
+    if torch.cuda.is_available():
+        _run_test(torch.device("cuda"))
+        _run_padding_test(torch.device("cuda"))
+    if torch.backends.mps.is_available():
+        _run_test(torch.device("mps"))
+        _run_padding_test(torch.device("mps"))
+    if torch.cuda.is_available():
+        bench()

--- a/train.py
+++ b/train.py
@@ -289,14 +289,35 @@ def main():
     )
 
     global_batch_size_requested = args.batch_size
+
+    accelerator = args.accelerator
+    if accelerator == "auto":
+        if torch.cuda.is_available():
+            accelerator = "cuda"
+        elif torch.backends.mps.is_available():
+            accelerator = "mps"
+        else:
+            accelerator = "cpu"
+
     # temporarily default to using only device 0 if user didn't specify --gpus
     # doing this so that batch size is consistent since if we rely on "auto" behavior
     # we don't know at this point in the code what the world size is.
     # TODO: refactor initialization so that we can support default behavior of "auto" with proper batch sizing
-    if args.gpus:
-        try:
-            devices = [int(x) for x in args.gpus.rstrip(",").split(",") if x]
-        except ValueError:
+    if accelerator == "cuda":
+        if args.gpus:
+            try:
+                devices = [int(x) for x in args.gpus.rstrip(",").split(",") if x]
+            except ValueError:
+                print(
+                    f"Invalid --gpus argument: '{args.gpus}'. "
+                    "Expected a comma separated list of ints, e.g. 0,1",
+                    file=sys.stderr,
+                )
+                return
+        else:
+            devices = [0]
+        n_devices = len(devices)
+        if n_devices == 0:
             print(
                 f"Invalid --gpus argument: '{args.gpus}'. "
                 "Expected a comma separated list of ints, e.g. 0,1",
@@ -304,15 +325,13 @@ def main():
             )
             return
     else:
-        devices = [0]
-    n_devices = len(devices)
-    if n_devices == 0:
-        print(
-            f"Invalid --gpus argument: '{args.gpus}'. "
-            "Expected a comma separated list of ints, e.g. 0,1",
-            file=sys.stderr,
-        )
-        return
+        if args.gpus:
+            print(
+                f"Warning: --gpus is ignored for accelerator='{accelerator}'",
+                file=sys.stderr,
+            )
+        devices = 1
+        n_devices = 1
     if global_batch_size_requested % n_devices != 0:
         raise ValueError(
             f"--batch-size {global_batch_size_requested} must be divisible by number of gpus ({n_devices}). "
@@ -407,8 +426,8 @@ def main():
     trainer = L.Trainer(
         default_root_dir=logdir,
         max_epochs=args.max_epochs,
-        accelerator="cuda",
-        strategy="ddp" if len(devices) > 1 else "auto",
+        accelerator=accelerator,
+        strategy="ddp" if n_devices > 1 else "auto",
         devices=devices,
         logger=loggers,
         callbacks=[

--- a/train.py
+++ b/train.py
@@ -299,6 +299,12 @@ def main():
         else:
             accelerator = "cpu"
 
+    if args.compile_backend == "cudagraphs" and accelerator != "cuda":
+        raise ValueError(
+            f"--compile-backend=cudagraphs requires accelerator='cuda', "
+            f"got accelerator='{accelerator}'. Use --compile-backend=inductor instead."
+        )
+
     # temporarily default to using only device 0 if user didn't specify --gpus
     # doing this so that batch size is consistent since if we rely on "auto" behavior
     # we don't know at this point in the code what the world size is.
@@ -333,10 +339,13 @@ def main():
         devices = 1
         n_devices = 1
     if global_batch_size_requested % n_devices != 0:
-        raise ValueError(
-            f"--batch-size {global_batch_size_requested} must be divisible by number of gpus ({n_devices}). "
-            f"Got --gpus={args.gpus or '0'}"
+        msg = (
+            f"--batch-size {global_batch_size_requested} must be divisible by "
+            f"number of devices ({n_devices}) for accelerator='{accelerator}'."
         )
+        if accelerator == "cuda":
+            msg += f" Got --gpus={args.gpus or '0'}."
+        raise ValueError(msg)
     per_gpu_batch_size = global_batch_size_requested // n_devices
     feature_name = args.nnue_lightning_config.features
 


### PR DESCRIPTION
Enables tasks that should not depend on CUDA. For example:
- cross checking evals
- converting checkpoints
- feature transformer tests

Add a pure-PyTorch implementation so the sparse feature transformer runs on CPU and MPS. Make the CuPy kernel import optional.

SparseLinearFunction.apply stays the public entry point and uses the CUDA kernel when available.