### PR TITLE
Fix loading .nnue files with cross_check_eval.py

### DIFF
--- a/cross_check_eval.py
+++ b/cross_check_eval.py
@@ -196,7 +196,10 @@ def main():
             QuantizationConfig(),
         )
     model.eval()
-    input_feature_name = model.model.input_feature_name
+    # --checkpoint - returns a Lightning NNUE wrapping a NNUEModel
+    # --net - returns the NNUEModel directly
+    inner_model = model.model if isinstance(model, NNUE) else model
+    input_feature_name = inner_model.input_feature_name
     fen_batch_provider = make_fen_batch_provider(args.data, batch_size)
 
     model_evals = []


### PR DESCRIPTION
Example usage:
```
python cross_check_eval.py \
  --engine ./stockfish-b1fb50 \
  --net ./nn-f68ec79f0fe3.nnue \
  --data .pgo/small.binpack \
  --count 1000
```