### PR TITLE
copy datasets to gpu while fetching 

### DIFF
--- a/data_loader/dataset.py
+++ b/data_loader/dataset.py
@@ -1,5 +1,6 @@
 import threading
 import queue
+from dataclasses import dataclass
 
 import torch
 from torch.utils.data import Dataset
@@ -16,6 +17,38 @@ def _recursive_pin(obj):
     elif isinstance(obj, (list, tuple)):
         return type(obj)(_recursive_pin(v) for v in obj)
     return obj
+
+
+def _recursive_to_device(obj, device, non_blocking=False):
+    if isinstance(obj, torch.Tensor):
+        return obj.to(device=device, non_blocking=non_blocking)
+    elif isinstance(obj, dict):
+        return {
+            k: _recursive_to_device(v, device, non_blocking) for k, v in obj.items()
+        }
+    elif isinstance(obj, (list, tuple)):
+        return type(obj)(_recursive_to_device(v, device, non_blocking) for v in obj)
+    return obj
+
+
+def _recursive_record_stream(obj, stream):
+    if isinstance(obj, torch.Tensor):
+        try:
+            obj.record_stream(stream)
+        except RuntimeError:
+            pass
+    elif isinstance(obj, dict):
+        for value in obj.values():
+            _recursive_record_stream(value, stream)
+    elif isinstance(obj, (list, tuple)):
+        for value in obj:
+            _recursive_record_stream(value, stream)
+
+
+@dataclass
+class _CudaPrefetchedItem:
+    item: object
+    ready_event: object
 
 
 class FenBatchProvider:
@@ -192,20 +225,37 @@ class SparseBatchDataset(torch.utils.data.IterableDataset):
 
 
 class FixedNumBatchesDataset(Dataset):
-    def __init__(self, dataset, num_batches, pin_memory=False, queue_size_limit=None):
+    def __init__(
+        self,
+        dataset,
+        num_batches,
+        pin_memory=False,
+        queue_size_limit=None,
+        device=None,
+    ):
         super().__init__()
         self.dataset = dataset
         self.iter = None  # Deferred to _start_prefetching
         self.num_batches = num_batches
-        self.pin_memory = pin_memory
+        self.device = torch.device(device) if device is not None else None
+        self.prefetch_to_device = self.device is not None and self.device.type == "cuda"
+        # Async H2D copies require pinned host memory.
+        self.pin_memory = pin_memory or self.prefetch_to_device
         if queue_size_limit is None:
-            queue_size_limit = 10 if pin_memory else 100
+            queue_size_limit = 10 if self.pin_memory else 100
 
         self._prefetch_queue = queue.Queue(maxsize=queue_size_limit)
         self._prefetch_thread = None
         self._stop_prefetching = threading.Event()
         self._prefetch_started = False
         self._lock = threading.Lock()
+
+    def _resolve_prefetch_device(self):
+        if not self.prefetch_to_device:
+            return None
+        if self.device.index is not None:
+            return self.device
+        return torch.device("cuda", torch.cuda.current_device())
 
     def _safe_put(self, item):
         """Helper to ensure we don't hang on shutdown if queue is full."""
@@ -218,12 +268,25 @@ class FixedNumBatchesDataset(Dataset):
 
     def _prefetch_worker(self):
         try:
+            prefetch_stream = None
+            prefetch_device = self._resolve_prefetch_device()
+            if prefetch_device is not None:
+                torch.cuda.set_device(prefetch_device)
+                prefetch_stream = torch.cuda.Stream(device=prefetch_device)
+
             while not self._stop_prefetching.is_set():
                 try:
                     item = next(self.iter)
-                    # Pin memory on worker thread if enabled.
                     if self.pin_memory:
                         item = _recursive_pin(item)
+                    if prefetch_stream is not None:
+                        with torch.cuda.stream(prefetch_stream):
+                            item = _recursive_to_device(
+                                item, prefetch_device, non_blocking=True
+                            )
+                            ready_event = torch.cuda.Event()
+                            ready_event.record(prefetch_stream)
+                        item = _CudaPrefetchedItem(item=item, ready_event=ready_event)
                     self._safe_put(item)
                 except StopIteration:
                     self._safe_put(None)
@@ -254,6 +317,12 @@ class FixedNumBatchesDataset(Dataset):
                 raise StopIteration("End of dataset reached")
             elif isinstance(item, Exception):
                 raise item
+            elif isinstance(item, _CudaPrefetchedItem):
+                prefetch_device = self._resolve_prefetch_device()
+                current_stream = torch.cuda.current_stream(device=prefetch_device)
+                current_stream.wait_event(item.ready_event)
+                _recursive_record_stream(item.item, current_stream)
+                return item.item
 
             return item
 

--- a/data_loader/dataset.py
+++ b/data_loader/dataset.py
@@ -270,7 +270,7 @@ class FixedNumBatchesDataset(Dataset):
     def _prefetch_worker(self):
         try:
             prefetch_stream = None
-            prefetch_device = self._resolve_prefetch_device()
+            prefetch_device = self._prefetch_device
             if prefetch_device is not None:
                 torch.cuda.set_device(prefetch_device)
                 prefetch_stream = torch.cuda.Stream(device=prefetch_device)

--- a/data_loader/dataset.py
+++ b/data_loader/dataset.py
@@ -246,6 +246,7 @@ class FixedNumBatchesDataset(Dataset):
 
         self._prefetch_queue = queue.Queue(maxsize=queue_size_limit)
         self._prefetch_thread = None
+        self._prefetch_device = None
         self._stop_prefetching = threading.Event()
         self._prefetch_started = False
         self._lock = threading.Lock()
@@ -297,6 +298,9 @@ class FixedNumBatchesDataset(Dataset):
     def _start_prefetching(self):
         with self._lock:
             if not self._prefetch_started:
+                # Resolve the concrete CUDA device on the consumer thread after the
+                # training process has selected its rank-local device.
+                self._prefetch_device = self._resolve_prefetch_device()
                 self.iter = iter(self.dataset)
                 self._prefetch_thread = threading.Thread(
                     target=self._prefetch_worker, daemon=True
@@ -318,7 +322,7 @@ class FixedNumBatchesDataset(Dataset):
             elif isinstance(item, Exception):
                 raise item
             elif isinstance(item, _CudaPrefetchedItem):
-                prefetch_device = self._resolve_prefetch_device()
+                prefetch_device = self._prefetch_device
                 current_stream = torch.cuda.current_stream(device=prefetch_device)
                 current_stream.wait_event(item.ready_event)
                 _recursive_record_stream(item.item, current_stream)

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -51,11 +51,13 @@ class NNUE(L.LightningModule):
         # lazy init so `resume_from_model` with config changes works correctly
         self.optimizer_wrapper = None
 
-        self.loss_metrics = MetricCollection ({
-            "train_loss_epoch": MeanMetric(),
-            "val_loss_epoch": MeanMetric(),
-            "test_loss_epoch": MeanMetric(),
-        })
+        self.loss_metrics = MetricCollection(
+            {
+                "train_loss_epoch": MeanMetric(),
+                "val_loss_epoch": MeanMetric(),
+                "test_loss_epoch": MeanMetric(),
+            }
+        )
 
     # --- setup optimizers and training hooks ---
     def configure_optimizers(self):

--- a/tests/test_ddp_loader.py
+++ b/tests/test_ddp_loader.py
@@ -3,9 +3,15 @@ import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
+import torch
+
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from data_loader.dataset import FixedNumBatchesDataset
+from data_loader.dataset import (
+    FixedNumBatchesDataset,
+    _CudaPrefetchedItem,
+    _recursive_to_device,
+)
 from data_loader.stream import _get_ddp_rank_and_world_size
 
 

--- a/tests/test_ddp_loader.py
+++ b/tests/test_ddp_loader.py
@@ -3,14 +3,10 @@ import sys
 import unittest
 from unittest.mock import MagicMock, patch
 
-import torch
-
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from data_loader.dataset import (
     FixedNumBatchesDataset,
-    _CudaPrefetchedItem,
-    _recursive_to_device,
 )
 from data_loader.stream import _get_ddp_rank_and_world_size
 

--- a/train.py
+++ b/train.py
@@ -42,6 +42,7 @@ class TimeLimitAfterCheckpoint(Callback):
                 f"[TimeLimit] Time limit reached ({elapsed:.1f}s), stopping after checkpoint."
             )
 
+
 class SimpleLineLogger(Callback):
     def __init__(
         self,
@@ -84,7 +85,7 @@ class SimpleLineLogger(Callback):
     def on_train_epoch_start(self, trainer, pl_module):
         if trainer.global_rank == 0:
             self.train_start_time = time.time()
-            print("-"*60)
+            print("-" * 60)
 
     @torch.compiler.disable
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
@@ -94,13 +95,18 @@ class SimpleLineLogger(Callback):
         current_step = batch_idx + 1
         total_batches = trainer.num_training_batches
 
-        if current_step % self._get_refresh_rate(trainer) == 0 or current_step == total_batches:
+        if (
+            current_step % self._get_refresh_rate(trainer) == 0
+            or current_step == total_batches
+        ):
             now = time.time()
             elapsed_total = now - self.train_start_time
             rate = current_step / elapsed_total if elapsed_total > 0 else 0
 
             remaining = (total_batches - current_step) / rate if rate > 0 else 0
-            loss_val = trainer.callback_metrics.get(self.train_metric_step, float('nan'))
+            loss_val = trainer.callback_metrics.get(
+                self.train_metric_step, float("nan")
+            )
 
             print(
                 f"Epoch {trainer.current_epoch:>2} (Train): "
@@ -122,11 +128,11 @@ class SimpleLineLogger(Callback):
             return
 
         pl_module._log_epoch_end(self.train_metric_epoch)
-        train_loss = trainer.callback_metrics.get(self.train_metric_epoch, float('nan'))
+        train_loss = trainer.callback_metrics.get(self.train_metric_epoch, float("nan"))
         print(
             f"Epoch {trainer.current_epoch:>2} (Train): "
             f"[{self.train_metric_epoch}={train_loss:.5f}]",
-            flush=True
+            flush=True,
         )
 
     # ==========================================
@@ -138,7 +144,9 @@ class SimpleLineLogger(Callback):
             self.val_start_time = time.time()
 
     @torch.compiler.disable
-    def on_validation_batch_end(self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx=0):
+    def on_validation_batch_end(
+        self, trainer, pl_module, outputs, batch, batch_idx, dataloader_idx=0
+    ):
         if trainer.global_rank != 0 or trainer.sanity_checking:
             return
 
@@ -149,7 +157,10 @@ class SimpleLineLogger(Callback):
         else:
             total_batches = sum(val_batches)
 
-        if current_step % self._get_refresh_rate(trainer) == 0 or current_step == total_batches:
+        if (
+            current_step % self._get_refresh_rate(trainer) == 0
+            or current_step == total_batches
+        ):
             now = time.time()
             elapsed_total = now - self.val_start_time
 
@@ -171,11 +182,11 @@ class SimpleLineLogger(Callback):
             return
 
         pl_module._log_epoch_end(self.val_metric)
-        val_loss = trainer.callback_metrics.get(self.val_metric, float('nan'))
+        val_loss = trainer.callback_metrics.get(self.val_metric, float("nan"))
         print(
             f"Epoch {trainer.current_epoch:>2} (Val): "
             f"[{self.val_metric}={val_loss:.5f}]",
-            flush=True
+            flush=True,
         )
 
 
@@ -190,6 +201,7 @@ def make_data_loaders(
     val_size,
     pin_memory,
     queue_size_limit,
+    prefetch_device=None,
 ):
     # Epoch and validation sizes are arbitrary
     features_name = feature_name
@@ -208,6 +220,7 @@ def make_data_loaders(
             (epoch_size + batch_size - 1) // batch_size,
             pin_memory=pin_memory,
             queue_size_limit=queue_size_limit,
+            device=prefetch_device,
         ),
         batch_size=None,
         batch_sampler=None,
@@ -222,6 +235,7 @@ def make_data_loaders(
                 (val_size + batch_size - 1) // batch_size,
                 pin_memory=pin_memory,
                 queue_size_limit=queue_size_limit,
+                device=prefetch_device,
             ),
             batch_size=None,
             batch_sampler=None,
@@ -240,6 +254,7 @@ def make_data_loaders(
                 (val_size + batch_size - 1) // batch_size,
                 pin_memory=pin_memory,
                 queue_size_limit=queue_size_limit,
+                device=prefetch_device,
             ),
             batch_size=None,
             batch_sampler=None,
@@ -401,6 +416,7 @@ def main():
         args.validation_size,
         pin_memory=args.pin_memory,
         queue_size_limit=args.data_loader_queue_size,
+        prefetch_device=torch.device("cuda"),
     )
 
     refresh_rate = max(1, (args.num_batches_per_epoch + 4) // 5)


### PR DESCRIPTION
- small speedup of 2-3 it/s locally, matters a bit more on slow memory systems, increases memory requirements on the GPU a bit

on a box with 2 training runs happening at the same this, this makes one go at 17 it/s while the other one is at 11 it/s

https://github.com/vondele/nettest/pull/302