### PR TITLE
Update cross_check_eval.py to parse latest eval format

### DIFF
--- a/cross_check_eval.py
+++ b/cross_check_eval.py
@@ -65,13 +65,12 @@ def eval_model_batch(model, batch: data_loader.SparseBatchPtr, device: str):
         )
         * 600.0
     ]
-    for i in range(len(evals)):
-        if them[i] > 0.5:
-            evals[i] = -evals[i]
     return evals
 
 
-re_nnue_eval = re.compile(r"NNUE evaluation:?\s*?([-+]?\d*?\.\d*)")
+re_nnue_eval = re.compile(
+    r"\(Big net\) NNUE evaluation\s+([-+]?\d+)\s+\(side to move, internal units\)"
+)
 
 
 def compute_basic_eval_stats(evals):
@@ -132,6 +131,8 @@ def compute_correlation(engine_evals, model_evals):
 
 
 def eval_engine_batch(engine_path, net_path, fens):
+    if not fens:
+        return []
     engine = subprocess.Popen(
         [engine_path],
         stdin=subprocess.PIPE,
@@ -146,7 +147,7 @@ def eval_engine_batch(engine_path, net_path, fens):
     query = "\n".join(parts)
     out = engine.communicate(input=query)[0]
     evals = re.findall(re_nnue_eval, out)
-    return [int(float(v) * 208) for v in evals]
+    return [int(v) for v in evals]
 
 
 def filter_fens(fens):

--- a/cross_check_eval.py
+++ b/cross_check_eval.py
@@ -68,8 +68,11 @@ def eval_model_batch(model, batch: data_loader.SparseBatchPtr, device: str):
     return evals
 
 
-re_nnue_eval = re.compile(
+re_nnue_eval_big = re.compile(
     r"\(Big net\) NNUE evaluation\s+([-+]?\d+)\s+\(side to move, internal units\)"
+)
+re_nnue_eval_small = re.compile(
+    r"\(Small net\) NNUE evaluation\s+([-+]?\d+)\s+\(side to move, internal units\)"
 )
 
 
@@ -130,7 +133,7 @@ def compute_correlation(engine_evals, model_evals):
     print("Max difference: {}".format(max_diff))
 
 
-def eval_engine_batch(engine_path, net_path, fens):
+def eval_engine_batch(engine_path, net_path, fens, net_type="big"):
     if not fens:
         return []
     engine = subprocess.Popen(
@@ -139,14 +142,16 @@ def eval_engine_batch(engine_path, net_path, fens):
         stdout=subprocess.PIPE,
         universal_newlines=True,
     )
-    parts = ["uci", "setoption name EvalFile value {}".format(net_path)]
+    option_name = "EvalFile" if net_type == "big" else "EvalFileSmall"
+    parts = ["uci", "setoption name {} value {}".format(option_name, net_path)]
     for fen in fens:
         parts.append("position fen {}".format(fen))
         parts.append("eval")
     parts.append("quit")
     query = "\n".join(parts)
     out = engine.communicate(input=query)[0]
-    evals = re.findall(re_nnue_eval, out)
+    pattern = re_nnue_eval_big if net_type == "big" else re_nnue_eval_small
+    evals = re.findall(pattern, out)
     return [int(v) for v in evals]
 
 
@@ -179,6 +184,13 @@ def main():
         default="cuda",
         choices=["cpu", "cuda", "mps"],
         help="Device for the NNUE model",
+    )
+    parser.add_argument(
+        "--net-type",
+        type=str,
+        default="big",
+        choices=["big", "small"],
+        help="Which net to evaluate: 'big' uses EvalFile, 'small' uses EvalFileSmall",
     )
 
     ModelConfig.add_model_args(parser)
@@ -225,7 +237,7 @@ def main():
         model_evals += eval_model_batch(model, b, args.device)
         data_loader.destroy_sparse_batch(b)
 
-        engine_evals += eval_engine_batch(args.engine, args.net, fens)
+        engine_evals += eval_engine_batch(args.engine, args.net, fens, args.net_type)
 
         done += len(fens)
         print("Processed {} positions.".format(done))


### PR DESCRIPTION
Parses the updated eval output format from https://github.com/official-stockfish/Stockfish/pull/6743

Example usage and output:

```
python cross_check_eval.py \
  --engine ./stockfish \
  --net ./nn-f68ec79f0fe3.nnue \
  --data .pgo/small.binpack \
  --device cpu

DDP rank: 0, world size: 1
Processed 0 positions.
Processed 1000 positions.
Min engine/model eval: -5101 / -5111.53271484375
Max engine/model eval: 5262 / 5288.47314453125
Avg engine/model eval: -34.874 / -32.7971590116322
Avg abs engine/model eval: 656.6 / 656.1607080521882
Relative engine error: 0.166215232113845
Relative model error: 6.218137119644796
Avg abs difference: 8.013353305250407
Min difference: 0.002590179443359375
Max difference: 256.188232421875
```