### PR TITLE
Improve cross_check_eval output.

### DIFF
--- a/cross_check_eval.py
+++ b/cross_check_eval.py
@@ -1,5 +1,7 @@
 import subprocess
 import re
+import math
+
 import tyro
 
 import chess
@@ -90,7 +92,8 @@ def eval_model_batch(model, batch: data_loader.SparseBatchPtr, device: str):
             black_values,
             psqt_indices,
             layer_stack_indices,
-        ) * model.quantization.nnue2score
+        )
+        * model.quantization.nnue2score
     ]
     return evals
 
@@ -103,63 +106,149 @@ re_nnue_eval_small = re.compile(
 )
 
 
+def sigmoid(x):
+    if x >= 0:
+        z = math.exp(-x)
+        return 1 / (1 + z)
+    else:
+        z = math.exp(x)
+        return z / (1 + z)
+
+
+def calculate_qf(score, offset, scaling):
+    q = (score - offset) / scaling
+    qm = (-score - offset) / scaling
+    return 0.5 * (1.0 + sigmoid(q) - sigmoid(qm))
+
+
+def get_percentile(data, percentile):
+    if not data:
+        return 0.0
+    sorted_data = sorted(data)
+    index = (len(sorted_data) - 1) * percentile
+    lower = math.floor(index)
+    upper = math.ceil(index)
+    weight = index - lower
+    return sorted_data[lower] * (1 - weight) + sorted_data[upper] * weight
+
+
 def compute_basic_eval_stats(evals):
-    min_engine_eval = min(evals)
-    max_engine_eval = max(evals)
-    avg_engine_eval = sum(evals) / len(evals)
-    avg_abs_engine_eval = sum(abs(v) for v in evals) / len(evals)
+    if not evals:
+        return 0, 0, 0, 0
+    min_val = min(evals)
+    max_val = max(evals)
+    avg_val = sum(evals) / len(evals)
+    avg_abs_val = sum(abs(v) for v in evals) / len(evals)
+    return min_val, max_val, avg_val, avg_abs_val
 
-    return min_engine_eval, max_engine_eval, avg_engine_eval, avg_abs_engine_eval
 
-
-def compute_correlation(engine_evals, model_evals):
+def compute_correlation(engine_evals, model_evals, fens):
     if len(engine_evals) != len(model_evals):
-        raise Exception(
-            "number of engine evals doesn't match the number of model evals. Got {} engine evals and {} model evals.".format(
-                len(engine_evals), len(model_evals)
+        raise Exception(f"Mismatch: {len(engine_evals)} vs {len(model_evals)}")
+
+    # Trainer parameters from your configuration
+    IN_OFFSET = 280.0
+    IN_SCALING = 353.0
+
+    data = []
+    abs_errors = []
+    q_errors = []
+
+    for e, m, f in zip(engine_evals, model_evals, fens):
+        ae = abs(m - e)
+        q_sf = calculate_qf(e, IN_OFFSET, IN_SCALING)
+        q_py = calculate_qf(m, IN_OFFSET, IN_SCALING)
+        qe = abs(q_py - q_sf)
+
+        abs_errors.append(ae)
+        q_errors.append(qe)
+        data.append(
+            {
+                "fen": f,
+                "sf": e,
+                "py": m,
+                "abs_err": ae,
+                "rel_err": ae / (abs(e) if e != 0 else 1.0),
+                "q_sf": q_sf,
+                "q_py": q_py,
+                "q_err": qe,
+            }
+        )
+
+    # R^2 Calculation for Scores
+    mean_sf = sum(engine_evals) / len(engine_evals)
+    ss_res = sum((d["sf"] - d["py"]) ** 2 for d in data)
+    ss_tot = sum((d["sf"] - mean_sf) ** 2 for d in data)
+    r_squared_score = 1 - (ss_res / ss_tot) if ss_tot != 0 else 0.0
+
+    # R^2 Calculation for Q (Expected Score)
+    mean_q_sf = sum(d["q_sf"] for d in data) / len(data)
+    ss_res_q = sum((d["q_sf"] - d["q_py"]) ** 2 for d in data)
+    ss_tot_q = sum((d["q_sf"] - mean_q_sf) ** 2 for d in data)
+    r_squared_q = 1 - (ss_res_q / ss_tot_q) if ss_tot_q != 0 else 0.0
+
+    # Summary Stats
+    en_min, en_max, en_avg, en_abs_avg = compute_basic_eval_stats(engine_evals)
+
+    W = 115
+    print("\n" + "=" * W)
+    print(f"{'CROSS-CHECK EVALUATION SUMMARY':^{W}}")
+    print("=" * W)
+    print(
+        f"{'Metric':<30} | {'Score (Internal Units)':>38} | {'Q (Win Probability)':>38}"
+    )
+    print("-" * W)
+
+    # 1. Values Summary
+    print(
+        f"{'Average Absolute Value':<30} | {en_abs_avg:>38.2f} | {sum(d['q_py'] for d in data) / len(data):>38.4f}"
+    )
+    print(
+        f"{'Min / Max Value':<30} | {en_min:>17.1f} / {en_max:<18.1f} | {min(d['q_py'] for d in data):>17.4f} / {max(d['q_py'] for d in data):<18.4f}"
+    )
+    print("-" * W)
+
+    # 2. Correlation and Errors Summary
+    print(
+        f"{'Correlation (R^2)':<30} | {r_squared_score:>38.6f} | {r_squared_q:>38.6f}"
+    )
+    print(
+        f"{'Avg Absolute Error (Mean)':<30} | {sum(abs_errors) / len(data):>38.2f} | {sum(q_errors) / len(data):>38.6f}"
+    )
+
+    # Quantiles (Sigma intervals)
+    for label, p in [
+        ("1-Sigma Error (68.3%)", 0.6827),
+        ("2-Sigma Error (95.5%)", 0.9545),
+        ("3-Sigma Error (99.7%)", 0.9973),
+    ]:
+        score_p = get_percentile(abs_errors, p)
+        q_p = get_percentile(q_errors, p)
+        print(f"{label:<30} | {score_p:>38.2f} | {q_p:>38.6f}")
+
+    print("=" * W)
+
+    # Detailed Top 5 Offenders
+    def print_top(title, key, col_name, fmt, is_pct=False):
+        print(f"\n>>> {title}")
+        top = sorted(data, key=lambda x: x[key], reverse=True)[:5]
+        print(
+            f"{col_name:>12} | {'SF Score':>10} | {'Py Score':>10} | {'SF Q':>8} | {'Py Q':>8} | {'FEN'}"
+        )
+        print("-" * W)
+        for d in top:
+            v = d[key] * 100 if is_pct else d[key]
+            v_str = f"{v:{fmt}}" + ("%" if is_pct else "")
+            print(
+                f"{v_str:>12} | {d['sf']:>10.1f} | {d['py']:>10.2f} | {d['q_sf']:>8.4f} | {d['q_py']:>8.4f} | {d['fen']}"
             )
-        )
 
-    min_engine_eval, max_engine_eval, avg_engine_eval, avg_abs_engine_eval = (
-        compute_basic_eval_stats(engine_evals)
+    print_top("TOP 5 LARGEST ABSOLUTE ERRORS", "abs_err", "Abs Err", "12.2f")
+    print_top(
+        "TOP 5 LARGEST RELATIVE ERRORS", "rel_err", "Rel Err", "11.2f", is_pct=True
     )
-    min_model_eval, max_model_eval, avg_model_eval, avg_abs_model_eval = (
-        compute_basic_eval_stats(model_evals)
-    )
-
-    print("Min engine/model eval: {} / {}".format(min_engine_eval, min_model_eval))
-    print("Max engine/model eval: {} / {}".format(max_engine_eval, max_model_eval))
-    print("Avg engine/model eval: {} / {}".format(avg_engine_eval, avg_model_eval))
-    print(
-        "Avg abs engine/model eval: {} / {}".format(
-            avg_abs_engine_eval, avg_abs_model_eval
-        )
-    )
-
-    relative_model_error = sum(
-        abs(model - engine) / (abs(engine) + 0.001)
-        for model, engine in zip(model_evals, engine_evals)
-    ) / len(engine_evals)
-    relative_engine_error = sum(
-        abs(model - engine) / (abs(model) + 0.001)
-        for model, engine in zip(model_evals, engine_evals)
-    ) / len(engine_evals)
-    min_diff = min(
-        abs(model - engine) for model, engine in zip(model_evals, engine_evals)
-    )
-    max_diff = max(
-        abs(model - engine) for model, engine in zip(model_evals, engine_evals)
-    )
-    print("Relative engine error: {}".format(relative_engine_error))
-    print("Relative model error: {}".format(relative_model_error))
-    print(
-        "Avg abs difference: {}".format(
-            sum(abs(model - engine) for model, engine in zip(model_evals, engine_evals))
-            / len(engine_evals)
-        )
-    )
-    print("Min difference: {}".format(min_diff))
-    print("Max difference: {}".format(max_diff))
+    print_top("TOP 5 LARGEST Q ERRORS", "q_err", "Q Err", "12.6f")
+    print("\n" + "=" * W + "\n")
 
 
 def eval_engine_batch(engine_path, net_path, fens, net_type="big"):
@@ -230,11 +319,13 @@ def main():
 
     model_evals = []
     engine_evals = []
+    all_fens = []
 
     done = 0
     print("Processed {} positions.".format(done))
     while done < cross_check_config.count:
         fens = filter_fens(next(fen_batch_provider))
+        all_fens += fens
 
         b = data_loader.get_sparse_batch_from_fens(
             input_feature_name, fens, [0] * len(fens), [1] * len(fens), [0] * len(fens)
@@ -246,13 +337,13 @@ def main():
             cross_check_config.engine,
             cross_check_config.net,
             fens,
-            cross_check_config.net_type
+            cross_check_config.net_type,
         )
 
         done += len(fens)
         print("Processed {} positions.".format(done))
 
-    compute_correlation(engine_evals, model_evals)
+    compute_correlation(engine_evals, model_evals, all_fens)
 
 
 if __name__ == "__main__":

--- a/cross_check_eval.py
+++ b/cross_check_eval.py
@@ -195,7 +195,7 @@ def compute_correlation(engine_evals, model_evals, fens):
     print(f"{'CROSS-CHECK EVALUATION SUMMARY':^{W}}")
     print("=" * W)
     print(
-        f"{'Metric':<30} | {'Score (Internal Units)':>38} | {'Q (Win Probability)':>38}"
+        f"{'Metric':<30} | {'Score (Internal Units)':>38} | {'Q (Expected Score)':>38}"
     )
     print("-" * W)
 


### PR DESCRIPTION
For current master net:
```
$ python -u cross_check_eval.py --engine /workspace/scratch/packages/stockfish/ed651aab544a330a9c8ae0dc2d8d51d5d48a8112-profile-build/Stockfish/src/stockfish --data /workspace/data/official-stockfish/master-binpacks/fishpack32.binpack --device=cuda --net-type=big --features=Full_Threats+HalfKAv2_hm^ --l1=1024 --l2=31 --count=10000 --net /workspace/scratch/packages/stockfish/ed651aab544a330a9c8ae0dc2d8d51d5d48a8112-profile-build/Stockfish/src/nn-f68ec79f0fe3.nnue
DDP rank: 0, world size: 1
Processed 0 positions.
Processed 1024 positions.
Processed 2048 positions.
Processed 3072 positions.
Processed 4096 positions.
Processed 5120 positions.
Processed 6144 positions.
Processed 7168 positions.
Processed 8192 positions.
Processed 9216 positions.
Processed 10240 positions.

===================================================================================================================
                                          CROSS-CHECK EVALUATION SUMMARY                                           
===================================================================================================================
Metric                         |                 Score (Internal Units) |                    Q (Win Probability)
-------------------------------------------------------------------------------------------------------------------
Average Absolute Value         |                                 279.42 |                                 0.5029
Min / Max Value                |           -1615.0 / 1596.0             |            0.0143 / 0.9849            
-------------------------------------------------------------------------------------------------------------------
Correlation (R^2)              |                               0.999406 |                               0.999453
Avg Absolute Error (Mean)      |                                   6.05 |                               0.003110
1-Sigma Error (68.3%)          |                                   6.83 |                               0.003528
2-Sigma Error (95.5%)          |                                  17.49 |                               0.008824
3-Sigma Error (99.7%)          |                                  42.35 |                               0.020847
===================================================================================================================

>>> TOP 5 LARGEST ABSOLUTE ERRORS
     Abs Err |   SF Score |   Py Score |     SF Q |     Py Q | FEN
-------------------------------------------------------------------------------------------------------------------
      137.48 |      189.0 |      51.52 |   0.6133 |   0.5313 | 8/5k2/8/5K2/6P1/8/8/8 w - - 5 52
      126.68 |     1263.0 |    1136.32 |   0.9647 |   0.9505 | 8/8/6p1/8/4K2k/r7/8/3Q4 w - - 37 96
       82.81 |       76.0 |     158.81 |   0.5461 |   0.5956 | 8/5k2/7R/5K2/5P2/7P/7r/8 w - - 1 63
       76.12 |      -18.0 |     -94.12 |   0.4891 |   0.4430 | 8/5k2/8/4K3/5P2/8/8/8 b - - 2 66
       72.98 |     -858.0 |    -785.02 |   0.1005 |   0.1198 | 4r3/8/5K2/1P1k4/P6R/8/8/8 b - - 8 58

>>> TOP 5 LARGEST RELATIVE ERRORS
     Rel Err |   SF Score |   Py Score |     SF Q |     Py Q | FEN
-------------------------------------------------------------------------------------------------------------------
    1775.32% |        0.0 |      17.75 |   0.5000 |   0.5108 | 1R6/8/8/7r/3K4/k1N5/8/8 w - - 3 70
    1155.63% |        1.0 |     -10.56 |   0.5006 |   0.4936 | 3k4/8/2PK4/8/8/8/8/8 w - - 3 64
    1089.21% |        0.0 |     -10.89 |   0.5000 |   0.4934 | r1b1k3/ppp1qpp1/2n5/6N1/3PP1nr/8/PPPQ2BP/RN2K2R w KQq - 1 4
    1013.21% |       -1.0 |     -11.13 |   0.4994 |   0.4932 | 8/5k2/R7/8/8/4N1K1/2r5/8 b - - 2 65
     936.14% |       -1.0 |     -10.36 |   0.4994 |   0.4937 | 8/8/3n3p/1k5N/3K4/8/8/7B b - - 5 66

>>> TOP 5 LARGEST Q ERRORS
       Q Err |   SF Score |   Py Score |     SF Q |     Py Q | FEN
-------------------------------------------------------------------------------------------------------------------
    0.081988 |      189.0 |      51.52 |   0.6133 |   0.5313 | 8/5k2/8/5K2/6P1/8/8/8 w - - 5 52
    0.049480 |       76.0 |     158.81 |   0.5461 |   0.5956 | 8/5k2/7R/5K2/5P2/7P/7r/8 w - - 1 63
    0.046055 |      -18.0 |     -94.12 |   0.4891 |   0.4430 | 8/5k2/8/4K3/5P2/8/8/8 b - - 2 66
    0.039010 |     -150.0 |    -216.80 |   0.4097 |   0.3706 | 8/6k1/8/4r3/2R1P2P/5K2/8/8 b - - 26 92
    0.037854 |      -93.0 |     -30.40 |   0.4437 |   0.4815 | 8/8/3k4/5P2/5K2/8/8/8 b - - 3 84

===================================================================================================================
```