### PR TITLE
ft_perm.py and serialize.py refactor to allow full CPU or MPS training pipeline

### DIFF
--- a/data_loader/__init__.py
+++ b/data_loader/__init__.py
@@ -1,6 +1,6 @@
 from .config import DataloaderSkipConfig
 
-from .dataset import SparseBatchDataset, FenBatchProvider, FixedNumBatchesDataset
+from .dataset import SparseBatchDataset, SparseBatchProvider, FenBatchProvider, FixedNumBatchesDataset
 
 from .stream import get_sparse_batch_from_fens, destroy_sparse_batch
 
@@ -9,6 +9,7 @@ from ._native import SparseBatchPtr, FenBatchPtr
 __all__ = [
     "DataloaderSkipConfig",
     "SparseBatchDataset",
+    "SparseBatchProvider",
     "FenBatchProvider",
     "FixedNumBatchesDataset",
     "get_sparse_batch_from_fens",

--- a/data_loader/_native.py
+++ b/data_loader/_native.py
@@ -212,9 +212,7 @@ class CDataLoaderAPI:
 type SparseBatchPtr = ctypes._Pointer[SparseBatch]
 type FenBatchPtr = ctypes._Pointer[FenBatch]
 
-
 try:
     c_lib = CDataLoaderAPI()
 except FileNotFoundError as e:
-    print(e)
-    exit(1)
+    raise ImportError(f"Failed to initialize CDataLoaderAPI: {e}.")

--- a/ftperm.py
+++ b/ftperm.py
@@ -6,9 +6,9 @@ Example use:
 
 1. Generate the activation matrix for some sample dataset.
 
-python ftperm.py gather --data=data\fishpack32.binpack --net=networks\nn-5af11540bbfe.nnue --count=1000000 --features=HalfKAv2_hm --out ftact1m.npy
+python ftperm.py gather --data=data\fishpack32.binpack --net=networks\nn-5af11540bbfe.nnue --count=1000000 --features=HalfKAv2_hm^ --out ftact1m.npy
 
-python ftperm.py gather --data=noob_master_leaf_static_d12_85M_0.binpack --net=nn-5af11540bbfe.nnue --count=10000 --features=HalfKAv2_hm --out ftact1m.npy
+python ftperm.py gather --data=noob_master_leaf_static_d12_85M_0.binpack --net=nn-5af11540bbfe.nnue --count=10000 --features=HalfKAv2_hm^ --out ftact1m.npy
 
 2. Find a permutation
 
@@ -19,22 +19,22 @@ python ftperm.py find_perm --data=ftact1m.npy --out=ftact.perm
 python ftperm.py eval_perm --data=ftact1m.npy --perm=ftact.perm
 
 4. Apply permutation and save
-python serialize.py nn-5af11540bbfe.nnue permuted.nnue --features=HalfKAv2_hm --ft_perm=ftact.perm
+python serialize.py nn-5af11540bbfe.nnue permuted.nnue --features=HalfKAv2_hm^ --ft_perm=ftact.perm
 
 ----------------------------------------------------------------
 
 OR do the whole process in one step
 
-python serialize.py networks\nn-5af11540bbfe.nnue permuted.nnue --features=HalfKAv2_hm --ft_optimize --ft_optimize_data=data\fishpack32.binpack --ft_optimize_count=1000000
+python serialize.py networks\nn-5af11540bbfe.nnue permuted.nnue --features=HalfKAv2_hm^ --ft_optimize --ft_optimize_data=data\fishpack32.binpack --ft_optimize_count=1000000
 
-python serialize.py nn-5af11540bbfe.nnue permuted.nnue --features=HalfKAv2_hm --ft_optimize --ft_optimize_data=noob_master_leaf_static_d12_85M_0.binpack --ft_optimize_count=10000
+python serialize.py nn-5af11540bbfe.nnue permuted.nnue --features=HalfKAv2_hm^ --ft_optimize --ft_optimize_data=noob_master_leaf_static_d12_85M_0.binpack --ft_optimize_count=10000
 
 """
 
 import copy
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 import time
-from typing import Callable, Generator, TypeAlias, Annotated, Union
+from typing import Callable, Generator, TypeAlias, Annotated, Union, Literal, TypeVar, Optional
 
 import tyro
 
@@ -42,8 +42,6 @@ from tyro.conf import (
     OmitArgPrefixes,
 )
 
-import chess
-import cupy as cp
 import numpy as np
 import numpy.typing as npt
 import torch
@@ -68,7 +66,7 @@ Algorithm by Daniel Monroe. Github @Ergodice.
 
 ZERO_BLOCK_SIZE = 4
 VERBOSE = False
-
+_DEVICE_OVERRIDE = None
 
 @dataclass
 class GatherConfig:
@@ -92,6 +90,15 @@ class GatherConfig:
     """
     number of datapoints to process
     """
+    loader_num_workers: int = 4
+    """Number of workers to use for data loading during gathering FT activations."""
+
+    loader_config: OmitArgPrefixes[data_loader.DataloaderSkipConfig] = field(
+        default_factory=data_loader.DataloaderSkipConfig
+    )
+    feature_config: OmitArgPrefixes[FeatureConfig] = field(
+        default_factory=FeatureConfig
+    )
 
 
 @dataclass
@@ -138,24 +145,33 @@ class FeaturePermutationConfig:
     ]
     use_cupy: Annotated[bool, tyro.conf.arg(name="cupy")] = True
     """
-    Cupy uses significant amounts of VRAM. Set to False to use numpy instead, which will be slower.
+    Set to False to use CPU instead of GPU. Kept for legacy CLI compatibility.
     """
-    device: int = 0
+    device: Union[int, Literal["cpu", "mps"]] = 0
     """
-    Device to use for cupy
+    Device to use. Can be integer (e.g. 0 for cuda:0), "mps", or "cpu"
     """
 
     model_config: OmitArgPrefixes[ModelConfig] = field(default_factory=ModelConfig)
 
-    feature_config: OmitArgPrefixes[FeatureConfig] = field(
-        default_factory=FeatureConfig
-    )
+
+def resolve_device(use_cupy: bool, device: Union[int, Literal["cpu", "mps"]]) -> str:
+    if not use_cupy:
+        return "cpu"
+    if _DEVICE_OVERRIDE is not None:
+        d = str(_DEVICE_OVERRIDE)
+    else:
+        d = str(device)
+    if d.isdigit():
+        return f"cuda:{d}"
+    return d
 
 
-def batched(arr: npt.NDArray, batch_size: int) -> Generator[npt.NDArray, None, None]:
+T = TypeVar("T", npt.NDArray, torch.Tensor)
+def batched(arr: T, batch_size: int) -> Generator[T, None, None]:
     """
     Utility generator that yields chunks of array `arr` of size `batch_size`
-    Expects arr to be a numpy-like array
+    Expects arr to be a numpy-like array or torch Tensor
     """
     n_samples = arr.shape[0]
     idx = 0
@@ -184,108 +200,82 @@ def apply_rotate_right(perm: npt.NDArray, indices: tuple[int, ...]) -> None:
 
 
 def get_swapped_zero_positive_count(
-    actmat_flat: npt.NDArray[np.bool_], use_cupy: bool = True
-) -> int:
-    if use_cupy:
-        actmat_flat = cp.asarray(actmat_flat, dtype=cp.int8)
-
+    actmat_flat: torch.Tensor
+) -> torch.Tensor:
     shape = actmat_flat.shape
     # Group into blocks that are processed at once during inference
     # actmat is a boolean matrix of shape (N, L1 // 2) with "True" meaning 0
     actmat_chunked = actmat_flat.reshape(
-        (actmat_flat.shape[0], actmat_flat.shape[1] // ZERO_BLOCK_SIZE, ZERO_BLOCK_SIZE)
+        (shape[0], shape[1] // ZERO_BLOCK_SIZE, ZERO_BLOCK_SIZE)
     )
 
-    if use_cupy:
-        # Calculate number of zeros in each block
-        num_zeros = cp.sum(actmat_chunked, axis=2, keepdims=True)
-        # Broadcast back to the same shape as actmat_chunked so it's easier to work with
-        num_zeros = cp.tile(num_zeros, (1, 1, ZERO_BLOCK_SIZE))
+    # Calculate number of zeros in each block
+    num_zeros = torch.sum(actmat_chunked, dim=2, keepdim=True)
+    # Broadcast back to the same shape as actmat_chunked so it's easier to work with
+    num_zeros = num_zeros.tile((1, 1, ZERO_BLOCK_SIZE))
 
-        # Marks an element if all other elements in a block are zero.
-        #
-        # Example:
-        #                                   b  i   k      b  i   k      b  i   k
-        # slice                            [0, 13, :]    [0, 14, :]    [0, 15, :]
-        # num_zeros           = [... [... [3, 3, 3, 3], [1, 1, 1, 1], [4, 4, 4, 4] ...] ...]
-        # actmat_chunked      = [... [... [1, 1, 0, 1], [0, 0, 1, 0], [1, 1, 1, 1] ...] ...]
-        # rest_zero_indicator = [... [... [0, 0, 1, 0], [0, 0, 0, 0], [1, 1, 1, 1] ...] ...]
-        #
-        rest_zero_indicator = (
-            (num_zeros - actmat_chunked == ZERO_BLOCK_SIZE - 1)
-            .reshape(shape)
-            .astype(cp.int8)
-        )
+    # Marks an element if all other elements in a block are zero.
+    #
+    # Example:
+    #                                   b  i   k      b  i   k      b  i   k
+    # slice                            [0, 13, :]    [0, 14, :]    [0, 15, :]
+    # num_zeros           = [... [... [3, 3, 3, 3], [1, 1, 1, 1], [4, 4, 4, 4] ...] ...]
+    # actmat_chunked      = [... [... [1, 1, 0, 1], [0, 0, 1, 0], [1, 1, 1, 1] ...] ...]
+    # rest_zero_indicator = [... [... [0, 0, 1, 0], [0, 0, 0, 0], [1, 1, 1, 1] ...] ...]
+    #
+    rest_zero_indicator = (
+        (num_zeros - actmat_chunked.int() == ZERO_BLOCK_SIZE - 1)
+        .reshape(shape)
+    )
 
-        # Sum all possible pairs of elements in a single sample of actmat_flat and rest_zero_indicator.
-        # Aggregate sum over the whole batch.
-        # This tells us how much "good" a swap of i-th and j-th slices would do. It doesn't consider
-        # how much "bad" it would do though, that will be accounted for later, for performance reasons.
-        swapped_zero_count = cp.einsum(
-            "bi,bj->ij", actmat_flat, rest_zero_indicator, dtype=int
-        )
-
-    else:
-        # Same operation but with numpy
-        num_zeros = np.sum(actmat_chunked, axis=2, keepdims=True)
-        num_zeros = np.tile(num_zeros, (1, 1, ZERO_BLOCK_SIZE))
-
-        rest_zero_indicator = (
-            (num_zeros - actmat_chunked == ZERO_BLOCK_SIZE - 1)
-            .reshape(shape)
-            .astype(int)
-        )
-
-        swapped_zero_count = np.einsum("bi,bj->ij", actmat_flat, rest_zero_indicator)
+    # Sum all possible pairs of elements in a single sample of actmat_flat and rest_zero_indicator.
+    # Aggregate sum over the whole batch.
+    # This tells us how much "good" a swap of i-th and j-th slices would do. It doesn't consider
+    # how much "bad" it would do though, that will be accounted for later, for performance reasons.
+    # Note: float32 has full precision up to a batch size of around 16M, more than enough for current cases.
+    # int32 would offer full precision up to batch sizes of 2B instead.
+    swapped_zero_count = (
+        actmat_flat.to(torch.float32).T @ rest_zero_indicator.to(torch.float32)
+    )
 
     return swapped_zero_count
 
 
 def get_swapped_zero_increase(
-    actmat: npt.NDArray[np.bool_], use_cupy: bool = True
-) -> npt.NDArray[np.int_]:
+    actmat: torch.Tensor
+) -> torch.Tensor:
     n_neurons = actmat.shape[1]
     swapped_zero_count = 0
 
     # Process in batches since the arrays are too large
-    # TODO: Find a good batch size. Try lowest as possible as VRAM is an issue on low end devices.
-    BATCH_SIZE = 10000
+    BATCH_SIZE = 8192
     for actmat_batch in batched(actmat, BATCH_SIZE):
-        swapped_zero_count += get_swapped_zero_positive_count(
-            actmat_batch, use_cupy=use_cupy
-        )
+        swapped_zero_count += get_swapped_zero_positive_count(actmat_batch)
 
     # (L1/2) x (L1/2)
-    if use_cupy:
-        # Subtract from each i-th slice the positive value of the current i-th placement.
-        # This is the place where we account for how much "bad" it would do.
-        # It is done here because we process earlier in batches, but this operation is distributive,
-        # so it needs to only be done once at the end.
-        swapped_zero_increase = swapped_zero_count - cp.reshape(
-            cp.diag(swapped_zero_count), (1, n_neurons)
-        )
-        swapped_zero_increase = cp.asnumpy(swapped_zero_increase)
-
-    else:
-        swapped_zero_increase = swapped_zero_count - np.reshape(
-            np.diag(swapped_zero_count), (1, n_neurons)
-        )
+    # Subtract from each i-th slice the positive value of the current i-th placement.
+    # This is the place where we account for how much "bad" it would do.
+    # It is done here because we process earlier in batches, but this operation is distributive,
+    # so it needs to only be done once at the end.
+    swapped_zero_increase = swapped_zero_count - torch.reshape(
+        torch.diag(swapped_zero_count), (1, n_neurons)
+    )
 
     return swapped_zero_increase
 
 
 def get_score_change(
-    actmat: npt.NDArray[np.bool_], use_cupy: bool = True
-) -> npt.NDArray[np.int_]:
+    actmat: torch.Tensor
+) -> torch.Tensor:
     # actmat is a boolean matrix of shape (N, L1) with "True" meaning 0
 
     n_neurons = actmat.shape[1]
 
-    score_change = get_swapped_zero_increase(actmat, use_cupy)
+    score_change = get_swapped_zero_increase(actmat)
 
     # Kill off swaps between neurons in the same block
-    blocks = np.arange(n_neurons).reshape((n_neurons, 1)) // ZERO_BLOCK_SIZE
-    same_block_killer = 1 - (blocks == blocks.T).astype(int)
+    blocks = torch.arange(n_neurons, device=actmat.device).reshape((n_neurons, 1)) // ZERO_BLOCK_SIZE
+    same_block_killer = 1 - (blocks == blocks.T).to(torch.int)
     score_change = score_change * same_block_killer
     return score_change
 
@@ -296,10 +286,10 @@ class SwapResult:
     score_change: float
 
 
-SwapFunction: TypeAlias = Callable[[npt.NDArray[np.bool_], bool], SwapResult]
+SwapFunction: TypeAlias = Callable[[torch.Tensor], SwapResult]
 
 
-def make_swaps_2(actmat: npt.NDArray[np.bool_], use_cupy: bool = True) -> SwapResult:
+def make_swaps_2(actmat: torch.Tensor) -> SwapResult:
     """
     Returns a series of independent 2-swap operations that collectively improve the objective function.
     """
@@ -312,11 +302,11 @@ def make_swaps_2(actmat: npt.NDArray[np.bool_], use_cupy: bool = True) -> SwapRe
     n_samples = actmat.shape[0]
 
     # Compute the score change of swapping i-th and j-th neurons
-    score_change = get_score_change(actmat, use_cupy=use_cupy)
+    score_change = get_score_change(actmat)
     # Sum score_change[i, j] + score_change[j, i] to get the cumulative impact of the swap.
     score_change = score_change + score_change.T
 
-    def all_indices_in_same_block(i: np.int_) -> list[int]:
+    def all_indices_in_same_block(i: int) -> list[int]:
         """Returns a list of indices of all neurons in the same block as the i-th neuron."""
         # Floor to the start of the block.
         base = i // ZERO_BLOCK_SIZE * ZERO_BLOCK_SIZE
@@ -325,11 +315,11 @@ def make_swaps_2(actmat: npt.NDArray[np.bool_], use_cupy: bool = True) -> SwapRe
     swaps = []
     total_score_change = 0
     while True:
-        swap = np.argmax(score_change)
+        swap = torch.argmax(score_change).item()
         # argmax returns a flat index, so we need to recompute the position.
         i, j = swap // n_neurons, swap % n_neurons
 
-        improvement = score_change[i, j]
+        improvement = score_change[i, j].item()
         if improvement == 0:
             break
 
@@ -357,7 +347,7 @@ def make_swaps_2(actmat: npt.NDArray[np.bool_], use_cupy: bool = True) -> SwapRe
     return SwapResult(swaps, total_improvement)
 
 
-def make_swaps_3(actmat: npt.NDArray[np.bool_], use_cupy: bool = True) -> SwapResult:
+def make_swaps_3(actmat: torch.Tensor) -> SwapResult:
     """
     Returns a series of independent left-rotates operations that collectively improve the objective function.
     """
@@ -370,7 +360,7 @@ def make_swaps_3(actmat: npt.NDArray[np.bool_], use_cupy: bool = True) -> SwapRe
     n_samples = actmat.shape[0]
     n_blocks = n_neurons // ZERO_BLOCK_SIZE
 
-    score_changes = get_score_change(actmat, use_cupy=use_cupy)
+    score_changes = get_score_change(actmat)
 
     # For each neuron i, j, k we sum score_change[i, j] + score_change[j, k] + score_change[k, i]
     # This is the cumulative impact of the right-rotation.
@@ -384,18 +374,12 @@ def make_swaps_3(actmat: npt.NDArray[np.bool_], use_cupy: bool = True) -> SwapRe
     cycles = []
     total_score_change = 0
 
-    if use_cupy:
-        # We don't want to have to go through an enormous array so compress it to represent blocks rather than neurons
-        # Cupy doesn't support a list of axes so we go one by one.
-        max_values = cp.amax(
-            cp.reshape(score_changes, compressed_shape), axis=5, keepdims=False
-        )
-        max_values = cp.amax(max_values, axis=3, keepdims=False)
-        max_values = cp.amax(max_values, axis=1, keepdims=False)
-    else:
-        max_values = np.amax(
-            np.reshape(score_changes, compressed_shape), axis=(5, 3, 1), keepdims=False
-        )
+    # We don't want to have to go through an enormous array so compress it to represent blocks rather than neurons
+    max_values = torch.amax(
+        torch.reshape(score_changes, compressed_shape), dim=5, keepdim=False
+    )
+    max_values = torch.amax(max_values, dim=3, keepdim=False)
+    max_values = torch.amax(max_values, dim=1, keepdim=False)
 
     # Kill rotates that would only affect less than 3 different blocks.
     # We must do this, because the rest of the algorithm relies on it for correctness.
@@ -406,8 +390,8 @@ def make_swaps_3(actmat: npt.NDArray[np.bool_], use_cupy: bool = True) -> SwapRe
         max_values[:, block, block] = 0
 
     while True:
-        best_blocks = max_values.argmax()
-        improvement_blocks = max_values.flatten()[best_blocks]
+        best_blocks = torch.argmax(max_values).item()
+        improvement_blocks = max_values.flatten()[best_blocks].item()
         if improvement_blocks == 0:
             break
 
@@ -422,8 +406,8 @@ def make_swaps_3(actmat: npt.NDArray[np.bool_], use_cupy: bool = True) -> SwapRe
         local_score_changes = score_changes[
             i : i + ZERO_BLOCK_SIZE, j : j + ZERO_BLOCK_SIZE, k : k + ZERO_BLOCK_SIZE
         ]
-        best_neurons = local_score_changes.argmax()
-        improvement_neurons = local_score_changes.flatten()[best_neurons]
+        best_neurons = torch.argmax(local_score_changes).item()
+        improvement_neurons = local_score_changes.flatten()[best_neurons].item()
         assert improvement_blocks == improvement_neurons
         i1, j1, k1 = np.unravel_index(
             best_neurons, (ZERO_BLOCK_SIZE, ZERO_BLOCK_SIZE, ZERO_BLOCK_SIZE)
@@ -450,12 +434,16 @@ def make_swaps_3(actmat: npt.NDArray[np.bool_], use_cupy: bool = True) -> SwapRe
 
 
 def find_perm_impl(
-    actmat: npt.NDArray[np.bool_], use_cupy: bool, L1: int
+    actmat: Union[npt.NDArray[np.bool_], torch.Tensor], device_str: str, L1: int
 ) -> npt.NDArray[np.int_]:
-    actmat = np.reshape(actmat, (actmat.shape[0] * 2, actmat.shape[1] // 2))
-    if use_cupy:
-        actmat = cp.asarray(actmat, dtype=cp.int8)
-    actmat_orig = actmat.copy()
+    if isinstance(actmat, np.ndarray):
+        actmat = np.reshape(actmat, (actmat.shape[0] * 2, actmat.shape[1] // 2))
+        actmat = torch.from_numpy(actmat).to(device_str)
+    else:
+        actmat = actmat.reshape((actmat.shape[0] * 2, actmat.shape[1] // 2))
+        actmat = actmat.to(device_str)
+
+    actmat_orig = actmat.clone()
 
     total_score_change = 0
     perm = np.arange(L1 // 2)
@@ -478,7 +466,7 @@ def find_perm_impl(
 
         # Calculate a set of independent right rotates (so swaps for 2 element case)
         # that when applied improve the objective function
-        swap_result = swap_fn(actmat, use_cupy)
+        swap_result = swap_fn(actmat)
         for cycle in swap_result.swaps:
             # Update the current best permutation with the newly found adjustments.
             apply_rotate_right(perm, cycle)
@@ -517,28 +505,34 @@ def read_model(
         return reader.model
 
 
-def make_fen_batch_provider(
-    data_path: str, batch_size: int
-) -> data_loader.FenBatchProvider:
-    return data_loader.FenBatchProvider(
-        data_path,
-        True,
-        4,  # some speedup and avoids StopIteration from fetch_next_fen_batch.
-        batch_size,
-        data_loader.DataloaderSkipConfig(
-            random_fen_skipping=10,
-        ),
+def make_sparse_batch_provider(
+    data_path: str,
+    batch_size: int,
+    feature_set_name: str,
+    loader_num_workers: int = 4,
+    loader_config: Optional[data_loader.DataloaderSkipConfig] = None
+) -> data_loader.SparseBatchProvider:
+    if loader_config is None:
+        loader_config = data_loader.DataloaderSkipConfig(
+                random_fen_skipping=10,
+                filtered=True, # filtering checks
+        )
+    # overwrite defaults
+    elif loader_config.random_fen_skipping == 0 or not loader_config.filtered:
+        random_fen_skipping = loader_config.random_fen_skipping if loader_config.random_fen_skipping != 0 else 10
+        loader_config = replace(
+            loader_config,
+            random_fen_skipping=random_fen_skipping,
+            filtered=True,
+        )
+    return data_loader.SparseBatchProvider(
+        feature_set=feature_set_name,
+        filenames=[data_path],
+        cyclic=True,
+        num_workers=loader_num_workers,  # some speedup and avoids StopIteration from fetch_next_fen_batch.
+        batch_size=batch_size,
+        config=loader_config,
     )
-
-
-def filter_fens(fens: list[str]) -> list[str]:
-    # We don't want fens where a king is in check, as these cannot be evaluated by the engine.
-    filtered_fens = []
-    for fen in fens:
-        board = chess.Board(fen=fen)
-        if not board.is_check():
-            filtered_fens.append(fen)
-    return filtered_fens
 
 
 def quantize_ft(model: NNUEModel) -> None:
@@ -575,8 +569,11 @@ def forward_ft(
     return l0_.round()
 
 
-def eval_ft(model: NNUEModel, batch: data_loader.SparseBatchPtr) -> torch.Tensor:
+def eval_ft(model: NNUEModel, batch: data_loader.SparseBatchPtr, device_str: str) -> torch.Tensor:
     with torch.no_grad():
+        batch = tuple(
+            batch_part.to(device=device_str) for batch_part in batch
+        )
         (
             us,
             them,
@@ -588,7 +585,7 @@ def eval_ft(model: NNUEModel, batch: data_loader.SparseBatchPtr) -> torch.Tensor
             score,
             psqt_indices,
             layer_stack_indices,
-        ) = batch.contents.get_tensors("cuda")
+        ) = batch
         res = forward_ft(
             model,
             us,
@@ -634,36 +631,44 @@ def ft_permute(model: NNUEModel, ft_perm_path: str) -> None:
     ft_permute_impl(model, permutation)
 
 
-def gather_impl(model: NNUEModel, dataset: str, count: int) -> npt.NDArray[np.bool_]:
+def gather_impl(
+        model: NNUEModel,
+        dataset: str,
+        count: int,
+        device_str: str,
+        loader_workers: int = 4,
+        loader_config: Optional[data_loader.DataloaderSkipConfig] = None
+    ) -> npt.NDArray[np.bool_]:
     ZERO_POINT = 0.0  # Vary this to check hypothetical forced larger truncation to zero
-    BATCH_SIZE = 1000
+    BATCH_SIZE = 1024
 
     quantized_model = copy.deepcopy(model)
     quantize_ft(quantized_model)
-    quantized_model.cuda()
+    if device_str != "cpu":
+        quantized_model.to(device_str)
 
-    fen_batch_provider = make_fen_batch_provider(dataset, BATCH_SIZE)
+    sparse_batch_provider = make_sparse_batch_provider(
+        dataset,
+        BATCH_SIZE,
+        quantized_model.input_feature_name,
+        loader_num_workers=loader_workers,
+        loader_config=loader_config
+    )
 
     actmats = []
 
     done = 0
     print("Processed {} positions.".format(done))
     while done < count:
-        fens = filter_fens(next(fen_batch_provider))
+        # checks are already filtered by sparse_batch_provider.
+        s_batch = next(sparse_batch_provider)
 
-        b = data_loader.get_sparse_batch_from_fens(
-            quantized_model.input_feature_name,
-            fens,
-            [0] * len(fens),
-            [1] * len(fens),
-            [0] * len(fens),
-        )
-        actmat = eval_ft(quantized_model, b).cpu()
+        actmat = eval_ft(quantized_model, s_batch, device_str).cpu()
         actmat = actmat <= ZERO_POINT
-        actmats.append(actmat.numpy())
-        data_loader.destroy_sparse_batch(b)
+        actmat = actmat.numpy()
+        actmats.append(actmat)
 
-        done += len(fens)
+        done += len(actmat)
         print("Processed {} positions.".format(done))
 
     return np.concatenate(actmats, axis=0)
@@ -674,7 +679,7 @@ def command_gather(args: FeaturePermutationConfig) -> None:
     if args.subcommand.checkpoint:
         nnue = NNUE.load_from_checkpoint(
             args.subcommand.checkpoint,
-            feature_name=args.feature_config.features,
+            feature_name=args.subcommand.feature_config.features,
             config=args.model_config,
             quantize_config=QuantizationConfig(),
         )
@@ -683,14 +688,22 @@ def command_gather(args: FeaturePermutationConfig) -> None:
         assert args.subcommand.net is not None
         model = read_model(
             args.subcommand.net,
-            args.feature_config.features,
+            args.subcommand.feature_config.features,
             args.model_config,
             QuantizationConfig(),
         )
 
     model.eval()
 
-    actmat = gather_impl(model, args.subcommand.data, args.subcommand.count)
+    device_str = resolve_device(args.use_cupy, args.device)
+    actmat = gather_impl(
+        model,
+        args.subcommand.data,
+        args.subcommand.count,
+        device_str,
+        args.subcommand.loader_num_workers,
+        args.subcommand.loader_config
+    )
 
     with open(args.subcommand.out, "wb") as file:  # was: args.out
         np.save(file, actmat)
@@ -735,7 +748,8 @@ def command_find_perm(args: FeaturePermutationConfig) -> None:
     with open(args.subcommand.data, "rb") as file:
         actmat = np.load(file)
 
-    perm = find_perm_impl(actmat, args.use_cupy, args.model_config.L1)
+    device_str = resolve_device(args.use_cupy, args.device)
+    perm = find_perm_impl(actmat, device_str, args.model_config.L1)
 
     # perm = np.random.permutation([i for i in range(L1)])
     with open(args.subcommand.out, "wb") as file:
@@ -749,15 +763,20 @@ def ft_optimize(
     actmat_save_path: str | None = None,
     perm_save_path: str | None = None,
     use_cupy: bool = True,
+    device: Union[int, Literal["cpu", "mps"]] = 0,
+    loader_num_workers: int = 4,
+    loader_config: Optional[data_loader.DataloaderSkipConfig] = None,
 ) -> None:
+    device_str = resolve_device(use_cupy, device)
+
     print("Gathering activation data...")
-    actmat = gather_impl(model, dataset_path, count)
+    actmat = gather_impl(model, dataset_path, count, device_str, loader_num_workers, loader_config)
     if actmat_save_path is not None:
         with open(actmat_save_path, "wb") as file:
             np.save(file, actmat)
 
     print("Finding permutation...")
-    perm = find_perm_impl(actmat, use_cupy, model.L1)
+    perm = find_perm_impl(actmat, device_str, model.L1)
     if perm_save_path is not None:
         with open(perm_save_path, "wb") as file:
             np.save(file, perm)
@@ -769,16 +788,13 @@ def ft_optimize(
     ft_permute_impl(model, perm)
 
 
-def set_cupy_device(device: int) -> None:
-    if device is not None:
-        cp.cuda.runtime.setDevice(device)
-
+def set_cupy_device(device: Optional[int]=None) -> None:
+    # kept for legacy reasons.
+    global _DEVICE_OVERRIDE
+    _DEVICE_OVERRIDE = device
 
 def main() -> None:
     cfg = tyro.cli(FeaturePermutationConfig)
-
-    if cfg.use_cupy:
-        set_cupy_device(cfg.device)
 
     match cfg.subcommand:
         case GatherConfig():

--- a/ftperm.py
+++ b/ftperm.py
@@ -519,12 +519,15 @@ def make_sparse_batch_provider(
         )
     # overwrite defaults
     elif loader_config.random_fen_skipping == 0 or not loader_config.filtered:
+        print("[ft_perm.py] WARNING: Overwriting dataloader config to ensure some level of fen skipping and filtering, which are important for performance and correctness of ft perm finding.")
+        print("[ft_perm.py]   Before overwrites: {}".format(loader_config))
         random_fen_skipping = loader_config.random_fen_skipping if loader_config.random_fen_skipping != 0 else 10
         loader_config = replace(
             loader_config,
             random_fen_skipping=random_fen_skipping,
             filtered=True,
         )
+        print("[ft_perm.py]   After overwrites:  {}".format(loader_config))
     return data_loader.SparseBatchProvider(
         feature_set=feature_set_name,
         filenames=[data_path],
@@ -566,7 +569,8 @@ def forward_ft(
     # and we want to scale to 1.0=127, but a shift is faster than a division (in inference)
     l0_ = torch.cat(l0_s1, dim=1) * (1 / 512)
 
-    return l0_.round()
+    # Inference uses bitshift which is equvialent to rounding down (floor).
+    return l0_.floor()
 
 
 def eval_ft(model: NNUEModel, batch: data_loader.SparseBatchPtr, device_str: str) -> torch.Tensor:
@@ -644,8 +648,7 @@ def gather_impl(
 
     quantized_model = copy.deepcopy(model)
     quantize_ft(quantized_model)
-    if device_str != "cpu":
-        quantized_model.to(device_str)
+    quantized_model.to(device_str)
 
     sparse_batch_provider = make_sparse_batch_provider(
         dataset,
@@ -680,8 +683,12 @@ def command_gather(args: FeaturePermutationConfig) -> None:
         nnue = NNUE.load_from_checkpoint(
             args.subcommand.checkpoint,
             feature_name=args.subcommand.feature_config.features,
-            config=args.model_config,
+            config=M.NNUELightningConfig(
+                features=args.subcommand.feature_config,
+                model_config=args.model_config,
+            ),
             quantize_config=QuantizationConfig(),
+            map_location=torch.device("cpu"),
         )
         model = nnue.model
     else:

--- a/ftperm.py
+++ b/ftperm.py
@@ -88,7 +88,7 @@ class GatherConfig:
     """
     count: int = 1000
     """
-    number of datapoints to process
+    number of datapoints to process (lower bound, actual count will be a multi of batch_size=1024)
     """
     loader_num_workers: int = 4
     """Number of workers to use for data loading during gathering FT activations."""
@@ -569,7 +569,7 @@ def forward_ft(
     # and we want to scale to 1.0=127, but a shift is faster than a division (in inference)
     l0_ = torch.cat(l0_s1, dim=1) * (1 / 512)
 
-    # Inference uses bitshift which is equvialent to rounding down (floor).
+    # Inference uses bitshift which is equivalent to rounding down (floor).
     return l0_.floor()
 
 
@@ -684,7 +684,6 @@ def command_gather(args: FeaturePermutationConfig) -> None:
             args.subcommand.checkpoint,
             feature_name=args.subcommand.feature_config.features,
             config=M.NNUELightningConfig(
-                features=args.subcommand.feature_config,
                 model_config=args.model_config,
             ),
             quantize_config=QuantizationConfig(),

--- a/serialize.py
+++ b/serialize.py
@@ -7,7 +7,11 @@ from dataclasses import dataclass, field
 from typing import Optional, Literal, Annotated, Union
 from tyro.conf import OmitArgPrefixes, Positional
 
-from data_loader import DataloaderSkipConfig
+try:
+    from data_loader.config import DataloaderSkipConfig
+except ImportError as e:
+    print(f"Error importing DataloaderSkipConfig: {e}")
+    DataloaderSkipConfig = None
 
 import model as M
 
@@ -51,7 +55,7 @@ class SerializeConfig:
     """Number of workers to use for data loading during FT optimization."""
 
     dataloader_config: OmitArgPrefixes[DataloaderSkipConfig] = field(
-        default_factory=DataloaderSkipConfig
+        default_factory=DataloaderSkipConfig if DataloaderSkipConfig is not None else lambda: None
     )
 
 

--- a/serialize.py
+++ b/serialize.py
@@ -4,8 +4,10 @@ import torch
 import tyro
 
 from dataclasses import dataclass, field
-from typing import Optional, Literal, Annotated
+from typing import Optional, Literal, Annotated, Union
 from tyro.conf import OmitArgPrefixes, Positional
+
+from data_loader import DataloaderSkipConfig
 
 import model as M
 
@@ -39,11 +41,18 @@ class SerializeConfig:
     """Number of positions to use for FT optimization."""
 
     use_cupy: Annotated[bool, tyro.conf.arg(name="cupy")] = True
-    """Disable CUPY usage if not enough GPU memory is available.
-    This will use numpy instead, which is slower."""
+    """Whether to run FT optimization on the resolved torch device.
+    Disable this to force FT optimization to run on the CPU instead."""
 
-    device: int = 0
-    """Device to use for cupy"""
+    device: Union[int, Literal["cpu", "mps"]] = 0
+    """Device to use for ft_optimize acceleration."""
+
+    loader_num_workers: int = 4
+    """Number of workers to use for data loading during FT optimization."""
+
+    dataloader_config: OmitArgPrefixes[DataloaderSkipConfig] = field(
+        default_factory=DataloaderSkipConfig
+    )
 
 
 @dataclass(frozen=True)
@@ -137,10 +146,6 @@ def main():
                 "Invalid number of positions to optimize FT with. (--ft_optimize_count)"
             )
 
-        if serialize_config.use_cupy:
-            if serialize_config.device is not None:
-                ftperm.set_cupy_device(serialize_config.device)
-
         if not args.source.endswith(".nnue"):
             nnue.model.input.coalesce()
             nnue.model.layer_stacks.coalesce_layer_stacks_inplace()
@@ -150,6 +155,9 @@ def main():
             serialize_config.ft_optimize_data,
             serialize_config.ft_optimize_count,
             use_cupy=serialize_config.use_cupy,
+            device=serialize_config.device,
+            loader_num_workers=serialize_config.loader_num_workers,
+            loader_config=serialize_config.dataloader_config,
         )
 
     if args.target.endswith(".ckpt"):

--- a/tests/test_training_pipeline_run.py
+++ b/tests/test_training_pipeline_run.py
@@ -15,6 +15,7 @@ def run_command(cmd_string):
         print(f"\nCommand failed with exit code {e.returncode}")
         sys.exit(e.returncode)
 
+# Can be potentially marked as pytest. Though the runtime is long. Thus for now it is left for manual and CI testing.
 def main():
     DEFAULT_TEST_DIR_STR = "./logs/training/runs/unittests_train_pipeline"
     parser = argparse.ArgumentParser(description="Execute training and serialization pipeline.")
@@ -64,23 +65,24 @@ def main():
                 print("Aborting. Directory must be removed before running to preserve version increment logic.")
                 sys.exit(1)
 
+    python_executable = shlex.quote(sys.executable)
     # --- 4. Define Pipeline Commands ---
     pipeline = [
-        f"python -u train.py ./.pgo/small.binpack --batch-size 1024 --l1=1024 --features=Full_Threats+HalfKAv2_hm^ --epoch-size 10000 --max_epochs=2 --default_root_dir {test_dir_str} {train_device_arg} {train_workers_arg}",
+        f"{python_executable} -u train.py ./.pgo/small.binpack --batch-size 1024 --l1=1024 --features=Full_Threats+HalfKAv2_hm^ --epoch-size 10000 --max_epochs=2 --default_root_dir \"{test_dir_str}\" {train_device_arg} {train_workers_arg}",
 
-        f"python -u serialize.py {test_dir_str}/lightning_logs/version_0/checkpoints/last.ckpt {test_dir_str}/lightning_logs/version_0/checkpoints/last.pt --features=Full_Threats+HalfKAv2_hm^ --l1=1024 {serialize_device_arg} {serialize_workers_arg}",
+        f"{python_executable} -u serialize.py \"{test_dir_str}\"/lightning_logs/version_0/checkpoints/last.ckpt \"{test_dir_str}\"/lightning_logs/version_0/checkpoints/last.pt --features=Full_Threats+HalfKAv2_hm^ --l1=1024 {serialize_device_arg} {serialize_workers_arg}",
 
-        f"python -u train.py ./.pgo/small.binpack --batch-size 2048 --l1=1024 --features=Full_Threats+HalfKAv2_hm^ --epoch-size 10000 --max_epochs=2 --default_root_dir {test_dir_str} --resume-from-model={test_dir_str}/lightning_logs/version_0/checkpoints/last.pt --validation-size=5000 {train_device_arg} {train_workers_arg}",
+        f"{python_executable} -u train.py ./.pgo/small.binpack --batch-size 2048 --l1=1024 --features=Full_Threats+HalfKAv2_hm^ --epoch-size 10000 --max_epochs=2 --default_root_dir \"{test_dir_str}\" --resume-from-model=\"{test_dir_str}\"/lightning_logs/version_0/checkpoints/last.pt --validation-size=5000 {train_device_arg} {train_workers_arg}",
 
-        f"python -u train.py ./.pgo/small.binpack --batch-size 2048 --l1=1024 --features=Full_Threats+HalfKAv2_hm^ --epoch-size 10000 --max_epochs=4 --default_root_dir {test_dir_str} --resume-from-checkpoint={test_dir_str}/lightning_logs/version_1/checkpoints/last.ckpt --validation-size=5000 {train_device_arg} {train_workers_arg}",
+        f"{python_executable} -u train.py ./.pgo/small.binpack --batch-size 2048 --l1=1024 --features=Full_Threats+HalfKAv2_hm^ --epoch-size 10000 --max_epochs=4 --default_root_dir \"{test_dir_str}\" --resume-from-checkpoint=\"{test_dir_str}\"/lightning_logs/version_1/checkpoints/last.ckpt --validation-size=5000 {train_device_arg} {train_workers_arg}",
 
-        f"python -u serialize.py {test_dir_str}/lightning_logs/version_2/checkpoints/last.ckpt {test_dir_str}/lightning_logs/version_2/checkpoints/last.pt --features=Full_Threats+HalfKAv2_hm^ --l1=1024 {serialize_device_arg} {serialize_workers_arg}",
+        f"{python_executable} -u serialize.py \"{test_dir_str}\"/lightning_logs/version_2/checkpoints/last.ckpt \"{test_dir_str}\"/lightning_logs/version_2/checkpoints/last.pt --features=Full_Threats+HalfKAv2_hm^ --l1=1024 {serialize_device_arg} {serialize_workers_arg}",
 
-        f"python -u serialize.py {test_dir_str}/lightning_logs/version_2/checkpoints/last.pt {test_dir_str}/lightning_logs/version_2/checkpoints/last.nnue --features=Full_Threats+HalfKAv2_hm^ --l1=1024 {serialize_device_arg} {serialize_workers_arg}",
+        f"{python_executable} -u serialize.py \"{test_dir_str}\"/lightning_logs/version_2/checkpoints/last.pt \"{test_dir_str}\"/lightning_logs/version_2/checkpoints/last.nnue --features=Full_Threats+HalfKAv2_hm^ --l1=1024 {serialize_device_arg} {serialize_workers_arg}",
 
-        f"python -u serialize.py {test_dir_str}/lightning_logs/version_2/checkpoints/last.nnue {test_dir_str}/lightning_logs/version_2/checkpoints/last.nnue --ft_optimize_data=./.pgo/small.binpack --features=Full_Threats+HalfKAv2_hm^ --l1=1024 --ft_optimize --ft_optimize_count=1000 --ft_compression=leb128 {serialize_device_arg} {serialize_workers_arg}",
+        f"{python_executable} -u serialize.py \"{test_dir_str}\"/lightning_logs/version_2/checkpoints/last.nnue \"{test_dir_str}\"/lightning_logs/version_2/checkpoints/last.nnue --ft_optimize_data=./.pgo/small.binpack --features=Full_Threats+HalfKAv2_hm^ --l1=1024 --ft_optimize --ft_optimize_count=1000 --ft_compression=leb128 {serialize_device_arg} {serialize_workers_arg}",
 
-        f"python -u serialize.py {test_dir_str}/lightning_logs/version_2/checkpoints/last.nnue {test_dir_str}/lightning_logs/version_2/checkpoints/last.nnue --features=Full_Threats+HalfKAv2_hm^ --l1=1024 --ft_compression=leb128 --out-sha {serialize_device_arg} {serialize_workers_arg}"
+        f"{python_executable} -u serialize.py \"{test_dir_str}\"/lightning_logs/version_2/checkpoints/last.nnue \"{test_dir_str}\"/lightning_logs/version_2/checkpoints/last.nnue --features=Full_Threats+HalfKAv2_hm^ --l1=1024 --ft_compression=leb128 --out-sha {serialize_device_arg} {serialize_workers_arg}"
     ]
 
     # --- 5. Execute ---
@@ -88,4 +90,5 @@ def main():
         run_command(cmd)
 
 if __name__ == "__main__":
+    # Must be called from repository root to ensure correct relative paths
     main()

--- a/tests/test_training_pipeline_run.py
+++ b/tests/test_training_pipeline_run.py
@@ -33,7 +33,7 @@ def main():
         is_int = False
 
     if is_int:
-        train_device_arg = f"--gpus={args.device},"
+        train_device_arg = f"--accelerator=cuda --gpus={args.device},"
     else:
         train_device_arg = f"--accelerator={args.device}"
 

--- a/tests/test_training_pipeline_run.py
+++ b/tests/test_training_pipeline_run.py
@@ -1,0 +1,91 @@
+import argparse
+import subprocess
+import shutil
+import sys
+from pathlib import Path
+import shlex
+
+def run_command(cmd_string):
+    """Executes a shell command string and halts execution if it fails."""
+    print(f"[TEST_TRAINING_PIPELINE_RUN] Run Command: {cmd_string}\n")
+    args = shlex.split(cmd_string)
+    try:
+        subprocess.run(args, check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"\nCommand failed with exit code {e.returncode}")
+        sys.exit(e.returncode)
+
+def main():
+    DEFAULT_TEST_DIR_STR = "./logs/training/runs/unittests_train_pipeline"
+    parser = argparse.ArgumentParser(description="Execute training and serialization pipeline.")
+    parser.add_argument("--num_workers", type=int, default=4, help="Number of workers for data loading (default 4)")
+    parser.add_argument("--device", type=str, default='cpu', help="Compute device (integer x for cuda:x, 'mps' or 'cpu'; default: 'cpu')")
+    parser.add_argument("--test-dir", type=str, default=DEFAULT_TEST_DIR_STR, help=f"Directory for test output (default: {DEFAULT_TEST_DIR_STR})")
+    parser.add_argument("-y", "--yes", action="store_true", help="Automatically delete existing output directory without prompting")
+    args = parser.parse_args()
+
+    # --- 1. Evaluate Device Arguments ---
+    try:
+        int(args.device)
+        is_int = True
+    except ValueError:
+        is_int = False
+
+    if is_int:
+        train_device_arg = f"--gpus={args.device},"
+    else:
+        train_device_arg = f"--accelerator={args.device}"
+
+    serialize_device_arg = f"--device={args.device}"
+
+    # --- 2. Evaluate Worker Arguments ---
+    train_workers_arg = f"--num_workers={args.num_workers}"
+    serialize_workers_arg = f"--loader_num_workers={args.num_workers}"
+
+    # --- 3. Directory Management ---
+    test_dir = Path(args.test_dir)
+    test_dir_str = str(test_dir)
+
+    if test_dir.exists():
+        if not test_dir.is_dir():
+            print(f"Error: Path {test_dir} exists but is a file, not a directory. Aborting.")
+            sys.exit(1)
+
+        if args.yes:
+            print(f"Directory {test_dir} exists. Auto-deleting due to -y flag.")
+            shutil.rmtree(test_dir)
+        else:
+            # Default to 'no' if the user just presses Enter
+            response = input(f"WARNING: Directory {test_dir} already exists. Delete it? [y/N]: ").strip().lower()
+            if response == 'y':
+                print(f"Deleting {test_dir}...")
+                shutil.rmtree(test_dir)
+            else:
+                print("Aborting. Directory must be removed before running to preserve version increment logic.")
+                sys.exit(1)
+
+    # --- 4. Define Pipeline Commands ---
+    pipeline = [
+        f"python -u train.py ./.pgo/small.binpack --batch-size 1024 --l1=1024 --features=Full_Threats+HalfKAv2_hm^ --epoch-size 10000 --max_epochs=2 --default_root_dir {test_dir_str} {train_device_arg} {train_workers_arg}",
+
+        f"python -u serialize.py {test_dir_str}/lightning_logs/version_0/checkpoints/last.ckpt {test_dir_str}/lightning_logs/version_0/checkpoints/last.pt --features=Full_Threats+HalfKAv2_hm^ --l1=1024 {serialize_device_arg} {serialize_workers_arg}",
+
+        f"python -u train.py ./.pgo/small.binpack --batch-size 2048 --l1=1024 --features=Full_Threats+HalfKAv2_hm^ --epoch-size 10000 --max_epochs=2 --default_root_dir {test_dir_str} --resume-from-model={test_dir_str}/lightning_logs/version_0/checkpoints/last.pt --validation-size=5000 {train_device_arg} {train_workers_arg}",
+
+        f"python -u train.py ./.pgo/small.binpack --batch-size 2048 --l1=1024 --features=Full_Threats+HalfKAv2_hm^ --epoch-size 10000 --max_epochs=4 --default_root_dir {test_dir_str} --resume-from-checkpoint={test_dir_str}/lightning_logs/version_1/checkpoints/last.ckpt --validation-size=5000 {train_device_arg} {train_workers_arg}",
+
+        f"python -u serialize.py {test_dir_str}/lightning_logs/version_2/checkpoints/last.ckpt {test_dir_str}/lightning_logs/version_2/checkpoints/last.pt --features=Full_Threats+HalfKAv2_hm^ --l1=1024 {serialize_device_arg} {serialize_workers_arg}",
+
+        f"python -u serialize.py {test_dir_str}/lightning_logs/version_2/checkpoints/last.pt {test_dir_str}/lightning_logs/version_2/checkpoints/last.nnue --features=Full_Threats+HalfKAv2_hm^ --l1=1024 {serialize_device_arg} {serialize_workers_arg}",
+
+        f"python -u serialize.py {test_dir_str}/lightning_logs/version_2/checkpoints/last.nnue {test_dir_str}/lightning_logs/version_2/checkpoints/last.nnue --ft_optimize_data=./.pgo/small.binpack --features=Full_Threats+HalfKAv2_hm^ --l1=1024 --ft_optimize --ft_optimize_count=1000 --ft_compression=leb128 {serialize_device_arg} {serialize_workers_arg}",
+
+        f"python -u serialize.py {test_dir_str}/lightning_logs/version_2/checkpoints/last.nnue {test_dir_str}/lightning_logs/version_2/checkpoints/last.nnue --features=Full_Threats+HalfKAv2_hm^ --l1=1024 --ft_compression=leb128 --out-sha {serialize_device_arg} {serialize_workers_arg}"
+    ]
+
+    # --- 5. Execute ---
+    for cmd in pipeline:
+        run_command(cmd)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* removed cupy dependent paths in `serialize.py` and `ftperm.py`
* complete refactor of `ftperm.py` to use torch instead of cupy for easier switching between devices
  * Improves performance (especially on CPU) as a side-effect
  * Fix small mismatch between inference and ft_perm (.round() -> .floor() for ft activation)
  * Allows DataLoaderSkipConfig to be passed for more fine-grained control
* added test script that runs a complete short train pipeline on device given by args