### PR TITLE
Refine saving

### DIFF
--- a/train.py
+++ b/train.py
@@ -54,9 +54,7 @@ class ConsolidatedCheckpoint(ModelCheckpoint):
         if self.dirpath:
             # Manually trigger a final save to last.ckpt
             path = os.path.join(self.dirpath, "last.ckpt")
-            if trainer.is_global_zero:
-                trainer.save_checkpoint(path)
-            trainer.strategy.barrier("consolidated_checkpoint_on_train_end")
+            trainer.save_checkpoint(path)
 
 
 class SimpleLineLogger(Callback):

--- a/train.py
+++ b/train.py
@@ -43,6 +43,20 @@ class TimeLimitAfterCheckpoint(Callback):
             )
 
 
+class ConsolidatedCheckpoint(ModelCheckpoint):
+    def __init__(self, *args, **kwargs):
+        # We force this to True to decouple from the validation schedule
+        kwargs.setdefault("save_on_train_epoch_end", True)
+        kwargs.setdefault("monitor", None)
+        super().__init__(*args, **kwargs)
+
+    def on_train_end(self, trainer, pl_module):
+        if self.dirpath:
+            # Manually trigger a final save to last.ckpt
+            path = os.path.join(self.dirpath, "last.ckpt")
+            trainer.save_checkpoint(path)
+
+
 class SimpleLineLogger(Callback):
     def __init__(
         self,
@@ -420,11 +434,10 @@ def main():
             print("Using default torch num_threads setting.")
         print("", flush=True)
 
-    checkpoint_callback = ModelCheckpoint(
+    checkpoint_callback = ConsolidatedCheckpoint(
         save_last=args.save_last_network,
         every_n_epochs=args.network_save_period,
         save_top_k=args.save_top_k,
-        monitor=None,
     )
 
     if accelerator == "mps":

--- a/train.py
+++ b/train.py
@@ -54,7 +54,9 @@ class ConsolidatedCheckpoint(ModelCheckpoint):
         if self.dirpath:
             # Manually trigger a final save to last.ckpt
             path = os.path.join(self.dirpath, "last.ckpt")
-            trainer.save_checkpoint(path)
+            if trainer.is_global_zero:
+                trainer.save_checkpoint(path)
+            trainer.strategy.barrier("consolidated_checkpoint_on_train_end")
 
 
 class SimpleLineLogger(Callback):


### PR DESCRIPTION
ensure checkpoints are saved with network_save_period, also in the presence of validation. ensure last.ckpt is always saved on ending training.

This wasn't quite right in the previous commit