### PR TITLE
Adding new loss params: lambda jitter

### DIFF
--- a/model/config.py
+++ b/model/config.py
@@ -78,7 +78,8 @@ class LossParams:
 
         if self.jitter_decay_lambda_batch < 0.0 or self.jitter_decay_lambda_batch >= 1.0:
             raise ValueError("jitter_decay_lambda_batch must be in the range [0.0, 1.0).")
-
+        if self.jitter_lambda_batch < 0.0 or self.jitter_lambda_sample < 0.0:
+            raise ValueError("jitter_lambda_batch and jitter_lambda_sample must be non-negative.")
 
 @dataclass(kw_only=True)
 class NNUELightningConfig(FeatureConfig):

--- a/model/config.py
+++ b/model/config.py
@@ -68,7 +68,7 @@ class LossParams:
 
     def __post_init__(self):
         if (self.start_lambda is not None) != (self.end_lambda is not None):
-            raise Exception(
+            raise ValueError(
                 "Either both or none of start_lambda and end_lambda must be specified."
             )
         if self.start_lambda is None:

--- a/model/config.py
+++ b/model/config.py
@@ -49,6 +49,12 @@ class LossParams:
     """lambda to use at first epoch."""
     end_lambda: float | None = None
     """lambda to use at last epoch."""
+    jitter_lambda_sample: float = 0.0
+    """std of normal distributed per sample jitter to add to lambda (default=0.0, no jitter)."""
+    jitter_lambda_batch: float = 0.0
+    """std of normal distributed per batch jitter to add to lambda (default=0.0, no jitter)."""
+    jitter_decay_lambda_batch: float = 0.0
+    """decay of batch jitter (0.0 means full decay -> independent jitter per batch. 1.0 = no decay, not allowed)."""
     pow_exp: float = 2.5
     """exponent of the power law used for the mean error (default=2.5)"""
     qp_asymmetry: float = 0.0
@@ -59,6 +65,19 @@ class LossParams:
     """weight boost parameter 2 (default=0.5)"""
     lambda_: Annotated[float, tyro.conf.arg(name="lambda")] = 1.0
     """1.0=train on evaluations, 0.0=train on game results, interpolates between (default=1.0)."""
+
+    def __post_init__(self):
+        if (self.start_lambda is not None) != (self.end_lambda is not None):
+            raise Exception(
+                "Either both or none of start_lambda and end_lambda must be specified."
+            )
+        if self.start_lambda is None:
+            self.start_lambda = self.lambda_
+        if self.end_lambda is None:
+            self.end_lambda = self.lambda_
+
+        if self.jitter_decay_lambda_batch < 0.0 or self.jitter_decay_lambda_batch >= 1.0:
+            raise ValueError("jitter_decay_lambda_batch must be in the range [0.0, 1.0).")
 
 
 @dataclass(kw_only=True)

--- a/model/lambda_utils.py
+++ b/model/lambda_utils.py
@@ -4,6 +4,7 @@ from torch import Tensor, nn
 
 from .config import LossParams
 
+
 class LambdaController(nn.Module):
     """
     lambda_ = 0.0 - purely based on game results
@@ -15,6 +16,7 @@ class LambdaController(nn.Module):
 
         # persistent=False ensures this is NOT saved in the standard model state_dict
         self.register_buffer("jitter_buffer", torch.zeros(1), persistent=False)
+
 
     def forward(self, loss_params: LossParams, current_epoch: int, max_epoch: int, is_training: bool, scorenet: Tensor) -> Tensor | float:
         lp = loss_params
@@ -39,6 +41,7 @@ class LambdaController(nn.Module):
         if torch.is_tensor(actual_lambda):
             return actual_lambda.clamp(0.0, 1.0)
         return max(0.0, min(1.0, actual_lambda))
+
 
     def on_save_checkpoint(self, checkpoint):
         # Manually save the training-only buffer to the Lightning checkpoint

--- a/model/lambda_utils.py
+++ b/model/lambda_utils.py
@@ -2,23 +2,25 @@ import math
 import torch
 from torch import Tensor, nn
 
+from .config import LossParams
+
 class LambdaController(nn.Module):
     """
     lambda_ = 0.0 - purely based on game results
     0.0 < lambda_ < 1.0 - interpolated score and result
     lambda_ = 1.0 - purely based on search scores
     """
-    def __init__(self, loss_params):
+    def __init__(self):
         super().__init__()
-        self.loss_params = loss_params
 
         # persistent=False ensures this is NOT saved in the standard model state_dict
         self.register_buffer("jitter_buffer", torch.zeros(1), persistent=False)
 
-    def forward(self, current_epoch: int, max_epoch: int, is_training: bool, scorenet: Tensor) -> Tensor | float:
-        lp = self.loss_params
-
-        actual_lambda = lp.start_lambda + (lp.end_lambda - lp.start_lambda) * (current_epoch / max_epoch)
+    def forward(self, loss_params: LossParams, current_epoch: int, max_epoch: int, is_training: bool, scorenet: Tensor) -> Tensor | float:
+        lp = loss_params
+        start_lambda = lp.start_lambda if lp.start_lambda is not None else lp.lambda_
+        end_lambda = lp.end_lambda if lp.end_lambda is not None else lp.lambda_
+        actual_lambda = start_lambda + (end_lambda - start_lambda) * (current_epoch / max_epoch)
 
         if is_training:
             if lp.jitter_lambda_batch != 0.0:

--- a/model/lambda_utils.py
+++ b/model/lambda_utils.py
@@ -1,0 +1,57 @@
+import math
+import torch
+from torch import Tensor, nn
+
+class LambdaController(nn.Module):
+    """
+    lambda_ = 0.0 - purely based on game results
+    0.0 < lambda_ < 1.0 - interpolated score and result
+    lambda_ = 1.0 - purely based on search scores
+    """
+    def __init__(self, loss_params):
+        super().__init__()
+        self.loss_params = loss_params
+
+        # persistent=False ensures this is NOT saved in the standard model state_dict
+        self.register_buffer("jitter_buffer", torch.zeros(1), persistent=False)
+
+    def forward(self, current_epoch: int, max_epoch: int, is_training: bool, scorenet: Tensor) -> Tensor | float:
+        lp = self.loss_params
+
+        actual_lambda = lp.start_lambda + (lp.end_lambda - lp.start_lambda) * (current_epoch / max_epoch)
+
+        if is_training:
+            if lp.jitter_lambda_batch != 0.0:
+                jitter_lambda_batch = lp.jitter_lambda_batch * math.sqrt(1 - lp.jitter_decay_lambda_batch ** 2)
+                batch_jitter_delta = jitter_lambda_batch * torch.randn_like(self.jitter_buffer)
+                self.jitter_buffer.mul_(lp.jitter_decay_lambda_batch).add_(batch_jitter_delta)
+                actual_lambda = actual_lambda + self.jitter_buffer.expand_as(scorenet)
+
+            if lp.jitter_lambda_sample != 0.0:
+                actual_lambda = actual_lambda + torch.randn_like(scorenet) * lp.jitter_lambda_sample
+        else:
+            eval_jitter_lambda = lp.jitter_lambda_sample + lp.jitter_lambda_batch
+            if eval_jitter_lambda != 0.0:
+                actual_lambda = actual_lambda + torch.randn_like(scorenet) * eval_jitter_lambda
+
+        if torch.is_tensor(actual_lambda):
+            return actual_lambda.clamp(0.0, 1.0)
+        return max(0.0, min(1.0, actual_lambda))
+
+    def on_save_checkpoint(self, checkpoint):
+        # Manually save the training-only buffer to the Lightning checkpoint
+        checkpoint["jitter_buffer_value"] = self.jitter_buffer
+
+    def on_load_checkpoint(self, pl_module, checkpoint):
+        trainer = pl_module.__dict__.get("_trainer", None)
+        is_resuming = (
+            trainer is not None and
+            getattr(trainer, "ckpt_path", None) is not None
+        )
+        if is_resuming:
+            if "jitter_buffer_value" in checkpoint:
+                jitter_buffer_value = checkpoint["jitter_buffer_value"].to(
+                    device=self.jitter_buffer.device,
+                    dtype=self.jitter_buffer.dtype,
+                )
+                self.jitter_buffer.copy_(jitter_buffer_value)

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -8,6 +8,7 @@ from torchmetrics import MeanMetric, MetricCollection
 from .config import NNUELightningConfig
 from .model import NNUEModel
 from .quantize import QuantizationConfig
+from .lambda_utils import LambdaController
 
 
 def _get_parameters(layers: list[nn.Module], get_biases: bool = False):
@@ -47,11 +48,6 @@ def calculate_sf_loss(scorenet, score, outcome, loss_params, actual_lambda):
 
 
 class NNUE(L.LightningModule):
-    """
-    lambda_ = 0.0 - purely based on game results
-    0.0 < lambda_ < 1.0 - interpolated score and result
-    lambda_ = 1.0 - purely based on search scores
-    """
 
     def __init__(
         self,
@@ -80,8 +76,8 @@ class NNUE(L.LightningModule):
         # lazy init so `resume_from_model` with config changes works correctly
         self.optimizer_wrapper = None
 
-        # register jitter buffer
-        self.register_buffer("jitter_buffer", torch.zeros(1), persistent=False)
+        # Initialize the lambda controller
+        self.lambda_scheduler = LambdaController(config.loss_params)
 
         self.loss_metrics = MetricCollection(
             {
@@ -195,21 +191,10 @@ class NNUE(L.LightningModule):
 
     def on_save_checkpoint(self, checkpoint):
         self.optimizer_wrapper.on_save_checkpoint(self, checkpoint)
-        checkpoint["jitter_buffer_value"] = self.jitter_buffer
+        self.lambda_scheduler.on_save_checkpoint(checkpoint)
 
     def on_load_checkpoint(self, checkpoint):
-        trainer = self.__dict__.get("_trainer", None)
-        is_resuming = (
-            trainer is not None and
-            getattr(trainer, "ckpt_path", None) is not None
-        )
-        if is_resuming:
-            if "jitter_buffer_value" in checkpoint:
-                jitter_buffer_value = checkpoint["jitter_buffer_value"].to(
-                    device=self.jitter_buffer.device,
-                    dtype=self.jitter_buffer.dtype,
-                )
-                self.jitter_buffer.copy_(jitter_buffer_value)
+        self.lambda_scheduler.on_load_checkpoint(self, checkpoint)
 
     def on_train_batch_start(self, batch, batch_idx):
         self.optimizer_wrapper.on_train_batch_start(self, batch, batch_idx)
@@ -271,32 +256,12 @@ class NNUE(L.LightningModule):
 
         scorenet = scorenet * self.model.quantization.nnue2score
 
-        loss_params = self.config.loss_params
-
-        actual_lambda = loss_params.start_lambda + (loss_params.end_lambda - loss_params.start_lambda) * (
-            self.current_epoch / self.max_epoch
+        actual_lambda = self.lambda_scheduler(
+            current_epoch=self.current_epoch,
+            max_epoch=self.max_epoch,
+            is_training=self.training,
+            scorenet=scorenet
         )
-
-        if self.training:
-            # Normalizing jitter_lambda_batch so that combined with decay,
-            # the effective jitter magnitude remains consistent across different decay rates.
-            if loss_params.jitter_lambda_batch != 0.0:
-                jitter_lambda_batch = loss_params.jitter_lambda_batch * math.sqrt(1 - loss_params.jitter_decay_lambda_batch ** 2)
-                batch_jitter_delta = jitter_lambda_batch * torch.randn_like(self.jitter_buffer)
-                self.jitter_buffer.mul_(loss_params.jitter_decay_lambda_batch).add_(batch_jitter_delta)
-                actual_lambda = actual_lambda + self.jitter_buffer.expand_as(scorenet)
-            if loss_params.jitter_lambda_sample != 0.0:
-                actual_lambda = actual_lambda + torch.randn_like(scorenet) * loss_params.jitter_lambda_sample
-        else:
-            # During evaluation, we allocate all jitter to the sample level for better consistency.
-            eval_jitter_lambda = loss_params.jitter_lambda_sample + loss_params.jitter_lambda_batch
-            if eval_jitter_lambda != 0.0:
-                actual_lambda = actual_lambda + torch.randn_like(scorenet) * eval_jitter_lambda
-
-        if torch.is_tensor(actual_lambda):
-            actual_lambda = actual_lambda.clamp(0.0, 1.0)
-        else:
-            actual_lambda = max(0.0, min(1.0, actual_lambda))
 
         sf_loss = calculate_sf_loss(scorenet, score, outcome, loss_params, actual_lambda)
 

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -1,6 +1,5 @@
 import lightning as L
 import torch
-import math
 
 from torch import Tensor, nn
 from torchmetrics import MeanMetric, MetricCollection

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -1,5 +1,7 @@
 import lightning as L
 import torch
+import math
+
 from torch import Tensor, nn
 from torchmetrics import MeanMetric, MetricCollection
 
@@ -77,6 +79,9 @@ class NNUE(L.LightningModule):
 
         # lazy init so `resume_from_model` with config changes works correctly
         self.optimizer_wrapper = None
+
+        # register jitter buffer
+        self.register_buffer("jitter_buffer", torch.zeros(1), persistent=False)
 
         self.loss_metrics = MetricCollection(
             {
@@ -190,6 +195,17 @@ class NNUE(L.LightningModule):
 
     def on_save_checkpoint(self, checkpoint):
         self.optimizer_wrapper.on_save_checkpoint(self, checkpoint)
+        checkpoint["jitter_buffer_value"] = self.jitter_buffer
+
+    def on_load_checkpoint(self, checkpoint):
+        trainer = self.__dict__.get("_trainer", None)
+        is_resuming = (
+            trainer is not None and
+            getattr(trainer, "ckpt_path", None) is not None
+        )
+        if is_resuming:
+            if "jitter_buffer_value" in checkpoint:
+                self.jitter_buffer.copy_(checkpoint["jitter_buffer_value"])
 
     def on_train_batch_start(self, batch, batch_idx):
         self.optimizer_wrapper.on_train_batch_start(self, batch, batch_idx)
@@ -256,6 +272,22 @@ class NNUE(L.LightningModule):
         actual_lambda = loss_params.start_lambda + (loss_params.end_lambda - loss_params.start_lambda) * (
             self.current_epoch / self.max_epoch
         )
+
+        if self.training:
+            # Normalizing jitter_lambda_batch so that combined with decay,
+            # the effective jitter magnitude remains consistent across different decay rates.
+            jitter_lambda_batch = loss_params.jitter_lambda_batch * math.sqrt(1 - loss_params.jitter_decay_lambda_batch ** 2)
+            batch_jitter_delta = jitter_lambda_batch * torch.randn_like(self.jitter_buffer)
+            self.jitter_buffer.mul_(loss_params.jitter_decay_lambda_batch).add_(batch_jitter_delta)
+            batch_jitter = self.jitter_buffer.expand_as(scorenet)
+            sample_jitter = torch.randn_like(scorenet) * loss_params.jitter_lambda_sample
+        else:
+            # During evaluation we move allocate all jitter to the sample level for better consistency.
+            batch_jitter = torch.zeros_like(scorenet)
+            sample_jitter = torch.randn_like(scorenet)
+            sample_jitter = sample_jitter * (loss_params.jitter_lambda_sample + loss_params.jitter_lambda_batch)
+        actual_lambda = actual_lambda + batch_jitter + sample_jitter
+        actual_lambda = actual_lambda.clamp(0.0, 1.0)
 
         sf_loss = calculate_sf_loss(scorenet, score, outcome, loss_params, actual_lambda)
 

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -76,7 +76,7 @@ class NNUE(L.LightningModule):
         self.optimizer_wrapper = None
 
         # Initialize the lambda controller
-        self.lambda_scheduler = LambdaController(config.loss_params)
+        self.lambda_scheduler = LambdaController()
 
         self.loss_metrics = MetricCollection(
             {
@@ -256,6 +256,7 @@ class NNUE(L.LightningModule):
         scorenet = scorenet * self.model.quantization.nnue2score
 
         actual_lambda = self.lambda_scheduler(
+            loss_params=self.config.loss_params,
             current_epoch=self.current_epoch,
             max_epoch=self.max_epoch,
             is_training=self.training,

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -263,7 +263,9 @@ class NNUE(L.LightningModule):
             scorenet=scorenet
         )
 
-        sf_loss = calculate_sf_loss(scorenet, score, outcome, loss_params, actual_lambda)
+        sf_loss = calculate_sf_loss(
+            scorenet, score, outcome, self.config.loss_params, actual_lambda
+        )
 
         self.loss_metrics[f"{loss_type}_epoch"].update(sf_loss)
         self.log(

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -205,7 +205,11 @@ class NNUE(L.LightningModule):
         )
         if is_resuming:
             if "jitter_buffer_value" in checkpoint:
-                self.jitter_buffer.copy_(checkpoint["jitter_buffer_value"])
+                jitter_buffer_value = checkpoint["jitter_buffer_value"].to(
+                    device=self.jitter_buffer.device,
+                    dtype=self.jitter_buffer.dtype,
+                )
+                self.jitter_buffer.copy_(jitter_buffer_value)
 
     def on_train_batch_start(self, batch, batch_idx):
         self.optimizer_wrapper.on_train_batch_start(self, batch, batch_idx)
@@ -276,18 +280,23 @@ class NNUE(L.LightningModule):
         if self.training:
             # Normalizing jitter_lambda_batch so that combined with decay,
             # the effective jitter magnitude remains consistent across different decay rates.
-            jitter_lambda_batch = loss_params.jitter_lambda_batch * math.sqrt(1 - loss_params.jitter_decay_lambda_batch ** 2)
-            batch_jitter_delta = jitter_lambda_batch * torch.randn_like(self.jitter_buffer)
-            self.jitter_buffer.mul_(loss_params.jitter_decay_lambda_batch).add_(batch_jitter_delta)
-            batch_jitter = self.jitter_buffer.expand_as(scorenet)
-            sample_jitter = torch.randn_like(scorenet) * loss_params.jitter_lambda_sample
+            if loss_params.jitter_lambda_batch != 0.0:
+                jitter_lambda_batch = loss_params.jitter_lambda_batch * math.sqrt(1 - loss_params.jitter_decay_lambda_batch ** 2)
+                batch_jitter_delta = jitter_lambda_batch * torch.randn_like(self.jitter_buffer)
+                self.jitter_buffer.mul_(loss_params.jitter_decay_lambda_batch).add_(batch_jitter_delta)
+                actual_lambda = actual_lambda + self.jitter_buffer.expand_as(scorenet)
+            if loss_params.jitter_lambda_sample != 0.0:
+                actual_lambda = actual_lambda + torch.randn_like(scorenet) * loss_params.jitter_lambda_sample
         else:
-            # During evaluation we move allocate all jitter to the sample level for better consistency.
-            batch_jitter = torch.zeros_like(scorenet)
-            sample_jitter = torch.randn_like(scorenet)
-            sample_jitter = sample_jitter * (loss_params.jitter_lambda_sample + loss_params.jitter_lambda_batch)
-        actual_lambda = actual_lambda + batch_jitter + sample_jitter
-        actual_lambda = actual_lambda.clamp(0.0, 1.0)
+            # During evaluation, we allocate all jitter to the sample level for better consistency.
+            eval_jitter_lambda = loss_params.jitter_lambda_sample + loss_params.jitter_lambda_batch
+            if eval_jitter_lambda != 0.0:
+                actual_lambda = actual_lambda + torch.randn_like(scorenet) * eval_jitter_lambda
+
+        if torch.is_tensor(actual_lambda):
+            actual_lambda = actual_lambda.clamp(0.0, 1.0)
+        else:
+            actual_lambda = max(0.0, min(1.0, actual_lambda))
 
         sf_loss = calculate_sf_loss(scorenet, score, outcome, loss_params, actual_lambda)
 

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -165,10 +165,13 @@ class NNUE(L.LightningModule):
 
         return retval
 
-
     def eval(self):
         return self.train(False)
 
+    def forward(self, *args, **kwargs):
+        return self.model(*args, **kwargs)
+
+    # --- lightning hooks ---
     def on_train_epoch_start(self):
         self.optimizer_wrapper.on_train_epoch_start(self)
 
@@ -209,9 +212,6 @@ class NNUE(L.LightningModule):
         )
 
     # --- Training step implementation ---
-
-    def forward(self, *args, **kwargs):
-        return self.model(*args, **kwargs)
 
     def training_step(self, batch, batch_idx):
         return self.step_(batch, batch_idx, "train_loss")

--- a/train.py
+++ b/train.py
@@ -300,23 +300,6 @@ def main():
     if len(args.validation_datasets) > 0:
         val_datasets = args.validation_datasets
 
-    loss_params = args.nnue_lightning_config.loss_params
-    if (loss_params.start_lambda is not None) != (loss_params.end_lambda is not None):
-        raise Exception(
-            "Either both or none of start_lambda and end_lambda must be specified."
-        )
-
-    loss_params.start_lambda = (
-        loss_params.start_lambda
-        if loss_params.start_lambda is not None
-        else loss_params.lambda_
-    )
-    loss_params.end_lambda = (
-        loss_params.end_lambda
-        if loss_params.end_lambda is not None
-        else loss_params.lambda_
-    )
-
     global_batch_size_requested = args.batch_size
 
     accelerator = args.accelerator
@@ -418,7 +401,7 @@ def main():
             f"batch_size(global)={global_batch_size_requested} | n_devices={n_devices} | batch_size(per_gpu)={per_gpu_batch_size}"
         )
         print("Loss parameters:")
-        print(loss_params)
+        print(args.nnue_lightning_config.loss_params)
         print("Feature set: {}".format(feature_name))
         print("Num inputs: {}".format(nnue.model.input.NUM_INPUTS))
 


### PR DESCRIPTION
Adds perturbations to the lambda parameter used for loss calculation.

Perturbation amount is controlled by newly added parameters.

This allows recipes to work without a lambda schedule (i.e. with lambda_start = lambda_end).

Despite the name, this is the "secret sauce" behind the success of the recipe https://github.com/vondele/nettest/pull/329