### PR TITLE
Improve weight clipping

### DIFF
--- a/model/callbacks.py
+++ b/model/callbacks.py
@@ -9,18 +9,34 @@ from .lightning_module import NNUE
 
 
 class WeightClippingCallback(L.Callback):
-    def on_train_batch_start(
+    @torch.no_grad()
+    @torch.compiler.disable
+    def on_train_batch_end(
         self,
         trainer: L.Trainer,
         pl_module: L.LightningModule,
+        outputs,
         batch,
         batch_idx: int,
     ) -> None:
         _, _ = trainer, batch  # Unused
         assert isinstance(pl_module, NNUE)
-        pl_module.model.clip_weights()
-        if batch_idx == 0:
-            pl_module.model.clip_input_weights()
+        pl_module.model.clip_weights(include_input=False)
+
+    @torch.no_grad()
+    @torch.compiler.disable
+    def on_train_epoch_end(self, trainer, pl_module):
+        _ = trainer # Unused
+        assert isinstance(pl_module, NNUE)
+        pl_module.model.clip_weights(include_input=True)
+
+    @torch.no_grad()
+    @torch.compiler.disable
+    def on_save_checkpoint(self, trainer, pl_module, checkpoint):
+        _, _ = trainer, checkpoint  # Unused
+        assert isinstance(pl_module, NNUE)
+        pl_module.model.clip_weights(include_input=True)
+
 
 class ExplicitSWACallback(L.Callback):
     def __init__(self, swa_start_epoch: int, save_dir: str):
@@ -39,12 +55,14 @@ class ExplicitSWACallback(L.Callback):
             self.swa_model.module.load_state_dict(tmp)
             self.to_eval = not self.to_eval
 
+    @torch.no_grad()
     @torch.compiler.disable
     def on_train_start(self, trainer, pl_module):
         if not trainer.is_global_zero:
             return
         self.swa_model = AveragedModel(pl_module.model)
 
+    @torch.no_grad()
     @torch.compiler.disable
     def on_train_epoch_end(self, trainer, pl_module):
         if not trainer.is_global_zero or trainer.current_epoch < self.swa_start_epoch:
@@ -53,6 +71,8 @@ class ExplicitSWACallback(L.Callback):
         self.swa_model.update_parameters(pl_module.model)
         pl_module.train()
 
+    @torch.no_grad()
+    @torch.compiler.disable
     def state_dict(self):
         # Prevent Lightning from saving the SWA callback's internal state
         # in the regular epoch checkpoints, avoiding redundant memory bloat.
@@ -60,9 +80,13 @@ class ExplicitSWACallback(L.Callback):
         # but that's an acceptable tradeoff for now.
         return {}
 
+    @torch.no_grad()
+    @torch.compiler.disable
     def load_state_dict(self, state_dict):
         _ = state_dict # Unused
 
+    @torch.no_grad()
+    @torch.compiler.disable
     def on_save_checkpoint(self, trainer, pl_module, checkpoint):
         _ = pl_module  # Unused
         if trainer.current_epoch >= self.swa_start_epoch:
@@ -75,6 +99,8 @@ class ExplicitSWACallback(L.Callback):
             if trainer.is_global_zero:
                 print(f"[ExplicitSWACallback] Stripping optimizer and lr_scheduler states from checkpoint at epoch {trainer.current_epoch} to save memory.")
 
+    @torch.no_grad()
+    @torch.compiler.disable
     def on_load_checkpoint(self, trainer, pl_module, checkpoint):
         _, _ = trainer, pl_module  # Unused
         checkpoint_epoch = checkpoint.get("epoch")
@@ -87,6 +113,8 @@ class ExplicitSWACallback(L.Callback):
                 f"Checkpoint epoch {checkpoint_epoch} > SWA start epoch {self.swa_start_epoch}"
             )
 
+    @torch.no_grad()
+    @torch.compiler.disable
     def on_train_end(self, trainer, pl_module):
         if trainer.current_epoch < self.swa_start_epoch:
             return

--- a/model/model.py
+++ b/model/model.py
@@ -37,7 +37,7 @@ class NNUEModel(nn.Module):
         self.input.init_weights(num_psqt_buckets, self.quantization.nnue2score)
 
     @torch.no_grad()
-    def clip_weights(self):
+    def clip_weights(self, include_input):
         """
         Clips the weights of the model based on the min/max values allowed
         by the quantization scheme.
@@ -65,8 +65,9 @@ class NNUEModel(nn.Module):
                             )
                     p_data_fp32.clamp_(min_weight, max_weight)
 
-    def clip_input_weights(self):
-        self.input.clip_weights(self.quantization)
+        if include_input:
+            self.input.clip_weights(self.quantization)
+
 
     def forward(
         self,


### PR DESCRIPTION
being more careful about properly clipping threat weights. In particular always clip before saving checkpoint

#475 occasionally causes crashes as it removed a safety "hack" and at the same time introduces an explicit fail when overflow is detected