### PR TITLE
[WIP] Better skip connections

### DIFF
--- a/.github/workflows/cpu-testrun.yml
+++ b/.github/workflows/cpu-testrun.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           repository: TonyCongqianWang/Stockfish
           path: Stockfish
-          ref: 4b1f879493f4dde4d6ade1749d8309bdfd9af553
+          ref: 1351e2ab7afe1a19cf9646cfb98ba4d8bdeab38e
           persist-credentials: false
 
       - name: Compile Compatible Stockfish

--- a/.github/workflows/cpu-testrun.yml
+++ b/.github/workflows/cpu-testrun.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           repository: TonyCongqianWang/Stockfish
           path: Stockfish
-          ref: d53076fde3b30216b5ee5bdcc569b31901279e47
+          ref: ba2b0f47549362c0587ab9c5f53b1f5e13aec799
           persist-credentials: false
 
       - name: Compile Compatible Stockfish

--- a/.github/workflows/cpu-testrun.yml
+++ b/.github/workflows/cpu-testrun.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           repository: TonyCongqianWang/Stockfish
           path: Stockfish
-          ref: ba2b0f47549362c0587ab9c5f53b1f5e13aec799
+          ref: 4b1f879493f4dde4d6ade1749d8309bdfd9af553
           persist-credentials: false
 
       - name: Compile Compatible Stockfish

--- a/.github/workflows/cpu-testrun.yml
+++ b/.github/workflows/cpu-testrun.yml
@@ -20,9 +20,9 @@ jobs:
       - name: Checkout Compatible Stockfish Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          repository: official-stockfish/Stockfish
+          repository: TonyCongqianWang/Stockfish
           path: Stockfish
-          ref: 313ea4ab0410872e99f0668c74edc7e49e9a0b6a
+          ref: d53076fde3b30216b5ee5bdcc569b31901279e47
           persist-credentials: false
 
       - name: Compile Compatible Stockfish

--- a/model/modules/config.py
+++ b/model/modules/config.py
@@ -9,7 +9,7 @@ import tyro
 class LayerStacksConfig:
     L1: Annotated[int, tyro.conf.arg(name="l1")] = 1024
     """Size of first hidden layer."""
-    L2: Annotated[int, tyro.conf.arg(name="l2")] = 31
+    L2: Annotated[int, tyro.conf.arg(name="l2")] = 32
     """Size of second hidden layer."""
     L3: Annotated[int, tyro.conf.arg(name="l3")] = 32
     """Size of third hidden layer."""

--- a/model/modules/layer_stacks.py
+++ b/model/modules/layer_stacks.py
@@ -36,7 +36,7 @@ class LayerStacks(nn.Module):
     ):
         l1c_ = self.l1(x, ls_indices, fake_quantize_weights)
         l1x_ = l1c_
-        l1x_out = l1c_[-2] - l1c_[-1]
+        l1x_out = l1c_[:, -2].view(-1, 1) - l1c_[:, -1].view(-1, 1)
 
         l1_sqr = torch.pow(l1x_, 2.0)
         if fake_quantize_acts:
@@ -52,7 +52,7 @@ class LayerStacks(nn.Module):
         l2c_ = self.l2(l1x_, ls_indices, fake_quantize_weights)
         if fake_quantize_acts:
             l2c_ = self.quantization.fake_quantize_ls_act(l2c_)
-        l2x_out = l2c_[-2] - l2c_[-1]
+        l2x_out = l2c_[:, -2].view(-1, 1) - l2c_[:, -1].view(-1, 1)
         l2x_ = self.quantization.clip_ls_act(l2c_)
 
         l3c_ = self.output(l2x_, ls_indices, fake_quantize_weights)
@@ -64,6 +64,7 @@ class LayerStacks(nn.Module):
         l3x_ = l3c_ + 2 * l1x_out + 2 * l2x_out
         if fake_quantize_acts:
             l3x_ = self.quantization.fake_quantize_output(l3x_)
+        assert l3x_.shape[1] == 1, f"Expected output shape (batch_size, 1), got {l3x_.shape}"
         return l3x_
 
     @torch.no_grad()

--- a/model/modules/layer_stacks.py
+++ b/model/modules/layer_stacks.py
@@ -35,8 +35,8 @@ class LayerStacks(nn.Module):
         fake_quantize_weights: bool=True,
     ):
         l1c_ = self.l1(x, ls_indices, fake_quantize_weights)
-        l1x_ = l1c_
         l1x_out = l1c_[:, -2].view(-1, 1) - l1c_[:, -1].view(-1, 1)
+        l1x_ = l1c_
 
         l1_sqr = torch.pow(l1x_, 2.0)
         if fake_quantize_acts:
@@ -50,9 +50,10 @@ class LayerStacks(nn.Module):
         l1x_ = self.quantization.clip_ls_act(l1x_)
 
         l2c_ = self.l2(l1x_, ls_indices, fake_quantize_weights)
+        l2x_out = l2c_[:, -2].view(-1, 1) - l2c_[:, -1].view(-1, 1)
+
         if fake_quantize_acts:
             l2c_ = self.quantization.fake_quantize_ls_act(l2c_)
-        l2x_out = l2c_[:, -2].view(-1, 1) - l2c_[:, -1].view(-1, 1)
         l2x_ = self.quantization.clip_ls_act(l2c_)
 
         l3c_ = self.output(l2x_, ls_indices, fake_quantize_weights)

--- a/model/modules/layer_stacks.py
+++ b/model/modules/layer_stacks.py
@@ -21,7 +21,7 @@ class LayerStacks(nn.Module):
         # there's a non-linearity and factorization breaks.
         # This is by design. The weights in the further layers should be
         # able to diverge a lot.
-        self.l1 = FactorizedStackedLinear(2 * self.L1 // 2, self.L2 + 1, count, quantization, "ls_l1")
+        self.l1 = FactorizedStackedLinear(2 * self.L1 // 2, self.L2, count, quantization, "ls_l1")
         self.l2 = StackedLinear(self.L2 * 2, self.L3, count, quantization, "ls_l2")
         self.output = StackedLinear(self.L3, 1, count, quantization, "ls_output")
 
@@ -35,7 +35,8 @@ class LayerStacks(nn.Module):
         fake_quantize_weights: bool=True,
     ):
         l1c_ = self.l1(x, ls_indices, fake_quantize_weights)
-        l1x_, l1x_out = l1c_.split(self.L2, dim=1)
+        l1x_ = l1c_
+        l1x_out = l1c_[-2] - l1c_[-1]
 
         l1_sqr = torch.pow(l1x_, 2.0)
         if fake_quantize_acts:
@@ -51,13 +52,16 @@ class LayerStacks(nn.Module):
         l2c_ = self.l2(l1x_, ls_indices, fake_quantize_weights)
         if fake_quantize_acts:
             l2c_ = self.quantization.fake_quantize_ls_act(l2c_)
+        l2x_out = l2c_[-2] - l2c_[-1]
         l2x_ = self.quantization.clip_ls_act(l2c_)
 
         l3c_ = self.output(l2x_, ls_indices, fake_quantize_weights)
         if fake_quantize_acts:
             l1x_out = self.quantization.fake_quantize_skip_act(l1x_out)
+            l2x_out = self.quantization.fake_quantize_skip_act(l2x_out)
 
-        l3x_ = l3c_ + l1x_out
+        # Skip connections are multiplied by 2 to increase range compared to the clipped path.
+        l3x_ = l3c_ + 2 * l1x_out + 2 * l2x_out
         if fake_quantize_acts:
             l3x_ = self.quantization.fake_quantize_output(l3x_)
         return l3x_


### PR DESCRIPTION
The last net update caused the net to not be able to output huge values anymore, which led to a regression in mating ability. This patch aims to tackle this weakness by adding more skip connections