### PR TITLE
Using custom lightweight modelcheckpoint implementation

### DIFF
--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,4 +1,4 @@
-from .callbacks import WeightClippingCallback, ExplicitSWACallback
+from .callbacks import WeightClippingCallback, ExplicitSWACallback, SimplePeriodicCheckpoint
 from .config import ModelConfig, LossParams, NNUELightningConfig
 from .optimizers import OptimizerConfig, RangerLiteWrapper, ScheduleFreeWrapper
 
@@ -22,6 +22,7 @@ from .utils import (
 __all__ = [
     "WeightClippingCallback",
     "ExplicitSWACallback",
+    "SimplePeriodicCheckpoint",
     "ModelConfig",
     "LossParams",
     "add_feature_args",

--- a/model/callbacks.py
+++ b/model/callbacks.py
@@ -158,6 +158,8 @@ class SimplePeriodicCheckpoint(L.Callback):
         if not self.save_last:
             assert self.every_n_epochs >= 1, "every_n_epochs must be at least 1 when save_last is False."
 
+    @torch.no_grad()
+    @torch.compiler.disable
     def __resolve_ckpt_dir(self, trainer: L.Trainer) -> str:
         """
         COPIED FROM PyTorch Lightning's ModelCheckpoint callback.
@@ -180,6 +182,8 @@ class SimplePeriodicCheckpoint(L.Callback):
 
         return ckpt_path
 
+    @torch.no_grad()
+    @torch.compiler.disable
     def on_train_start(self, trainer, pl_module):
         self.dirpath = self.__resolve_ckpt_dir(trainer)
         if trainer.is_global_zero:
@@ -188,6 +192,8 @@ class SimplePeriodicCheckpoint(L.Callback):
     def _is_in_swa_phase(self, trainer) -> bool:
         return self.swa_start_epoch >= 0 and trainer.current_epoch >= self.swa_start_epoch
 
+    @torch.no_grad()
+    @torch.compiler.disable
     def on_train_epoch_end(self, trainer, pl_module):
         if self._is_in_swa_phase(trainer):
             return
@@ -199,6 +205,8 @@ class SimplePeriodicCheckpoint(L.Callback):
         if (epoch + 1) % self.every_n_epochs == 0:
             self._save_and_rotate(trainer, epoch, step)
 
+    @torch.no_grad()
+    @torch.compiler.disable
     def _save_and_rotate(self, trainer, epoch: int, step: int):
         assert self.dirpath is not None
         os.makedirs(self.dirpath, exist_ok=True)
@@ -225,6 +233,8 @@ class SimplePeriodicCheckpoint(L.Callback):
                     except OSError:
                         pass
 
+    @torch.no_grad()
+    @torch.compiler.disable
     def on_train_end(self, trainer, pl_module):
         if not self.dirpath:
             return

--- a/model/callbacks.py
+++ b/model/callbacks.py
@@ -2,6 +2,8 @@ import lightning as L
 import torch
 import os
 import copy
+import shutil
+from collections import deque
 
 from torch.optim.swa_utils import AveragedModel
 
@@ -134,3 +136,101 @@ class ExplicitSWACallback(L.Callback):
         if trainer.is_global_zero:
             print(f"[ExplicitSWACallback] SWA model saved to {swa_savepath}")
         self.swap_weights(pl_module, to_eval=False)
+
+
+class SimplePeriodicCheckpoint(L.Callback):
+    def __init__(
+        self,
+        dirpath = None,
+        every_n_epochs: int = 1,
+        save_top_k: int = 1,
+        swa_start_epoch: int = -1,
+        save_last: bool = True
+    ):
+        super().__init__()
+        self.dirpath = dirpath
+        self.every_n_epochs = every_n_epochs
+        self.keep_last_k = save_top_k
+        self.swa_start_epoch = swa_start_epoch
+        self.save_last = save_last
+        self._saved_checkpoints = deque()
+
+        if not self.save_last:
+            assert self.every_n_epochs >= 1, "every_n_epochs must be at least 1 when save_last is False."
+
+    def __resolve_ckpt_dir(self, trainer: L.Trainer) -> str:
+        """
+        COPIED FROM PyTorch Lightning's ModelCheckpoint callback.
+        """
+        if self.dirpath is not None:
+            return self.dirpath
+
+        if len(trainer.loggers) > 0:
+            if trainer.loggers[0].save_dir is not None:
+                save_dir = trainer.loggers[0].save_dir
+            else:
+                save_dir = trainer.default_root_dir
+            name = trainer.loggers[0].name
+            version = trainer.loggers[0].version
+            version = version if isinstance(version, str) else f"version_{version}"
+            ckpt_path = os.path.join(save_dir, str(name), version, "checkpoints")
+        else:
+            # if no loggers, use default_root_dir
+            ckpt_path = os.path.join(trainer.default_root_dir, "checkpoints")
+
+        return ckpt_path
+
+    def on_train_start(self, trainer, pl_module):
+        self.dirpath = self.__resolve_ckpt_dir(trainer)
+        if trainer.is_global_zero:
+            os.makedirs(self.dirpath, exist_ok=True)
+
+    def _is_in_swa_phase(self, trainer) -> bool:
+        return self.swa_start_epoch >= 0 and trainer.current_epoch >= self.swa_start_epoch
+
+    def on_train_epoch_end(self, trainer, pl_module):
+        if self._is_in_swa_phase(trainer):
+            return
+
+        # PyTorch Lightning epochs are 0-indexed.
+        epoch = trainer.current_epoch
+        step = trainer.global_step
+
+        if (epoch + 1) % self.every_n_epochs == 0:
+            self._save_and_rotate(trainer, epoch, step)
+
+    def _save_and_rotate(self, trainer, epoch: int, step: int):
+        assert self.dirpath is not None
+        os.makedirs(self.dirpath, exist_ok=True)
+        if self.keep_last_k > 0:
+            filepath = os.path.join(self.dirpath, f"epoch={epoch}-step={step}.ckpt")
+        else:
+            filepath = os.path.join(self.dirpath, "last.ckpt")
+
+        trainer.save_checkpoint(filepath)
+
+        if self.keep_last_k > 0:
+            self._saved_checkpoints.append(filepath)
+
+            # File system operations must be restricted to global zero
+            if trainer.is_global_zero and self.save_last:
+                last_path = os.path.join(self.dirpath, "last.ckpt")
+                shutil.copy2(filepath, last_path)
+
+            while len(self._saved_checkpoints) > self.keep_last_k:
+                oldest_ckpt = self._saved_checkpoints.popleft()
+                if trainer.is_global_zero and os.path.exists(oldest_ckpt):
+                    try:
+                        os.remove(oldest_ckpt)
+                    except OSError:
+                        pass
+
+    def on_train_end(self, trainer, pl_module):
+        if not self.dirpath:
+            return
+
+        os.makedirs(self.dirpath, exist_ok=True)
+
+        epoch = trainer.current_epoch
+        step = trainer.global_step
+        self._save_and_rotate(trainer, epoch, step)

--- a/model/callbacks.py
+++ b/model/callbacks.py
@@ -153,10 +153,13 @@ class SimplePeriodicCheckpoint(L.Callback):
         self.keep_last_k = save_top_k
         self.swa_start_epoch = swa_start_epoch
         self.save_last = save_last
-        self._saved_checkpoints = deque()
 
+        self._saved_checkpoints = deque()
+        self._last_saved = None
+
+        assert self.every_n_epochs > 0, "every_n_epochs must be a positive integer."
         if not self.save_last:
-            assert self.every_n_epochs >= 1, "every_n_epochs must be at least 1 when save_last is False."
+            assert self.keep_last_k >= 1 or self.keep_last_k == -1, "save_top_k must be at least 1 when save_last is False."
 
     @torch.no_grad()
     @torch.compiler.disable
@@ -210,7 +213,12 @@ class SimplePeriodicCheckpoint(L.Callback):
     def _save_and_rotate(self, trainer, epoch: int, step: int):
         assert self.dirpath is not None
         os.makedirs(self.dirpath, exist_ok=True)
-        if self.keep_last_k > 0:
+        if self.keep_last_k > 0 or self.keep_last_k == -1:
+            if self._last_saved == (epoch, step):
+                # Skip if duplicate checkpoint for the same epoch and step.
+                # Prevents lost checkpoints due to rotating too often.
+                return
+            self._last_saved = (epoch, step)
             filepath = os.path.join(self.dirpath, f"epoch={epoch}-step={step}.ckpt")
         else:
             filepath = os.path.join(self.dirpath, "last.ckpt")

--- a/tests/test_training_pipeline_run.py
+++ b/tests/test_training_pipeline_run.py
@@ -68,13 +68,13 @@ def main():
     python_executable = shlex.quote(sys.executable)
     # --- 4. Define Pipeline Commands ---
     pipeline = [
-        f"{python_executable} -u train.py ./.pgo/small.binpack --batch-size 1024 --l1=1024 --features=Full_Threats+HalfKAv2_hm^ --epoch-size 10000 --max_epochs=2 --swa-start-epoch=1 --default_root_dir \"{test_dir_str}\" {train_device_arg} {train_workers_arg}",
+        f"{python_executable} -u train.py ./.pgo/small.binpack --batch-size 1024 --l1=1024 --features=Full_Threats+HalfKAv2_hm^ --epoch-size 10000 --max_epochs=2 --swa-start-epoch=1 --default_root_dir \"{test_dir_str}\" {train_device_arg} {train_workers_arg} --network_save_period 1",
 
         f"{python_executable} -u serialize.py \"{test_dir_str}\"/lightning_logs/version_0/checkpoints/last.ckpt \"{test_dir_str}\"/lightning_logs/version_0/checkpoints/last.pt --features=Full_Threats+HalfKAv2_hm^ --l1=1024 {serialize_device_arg} {serialize_workers_arg}",
 
-        f"{python_executable} -u train.py ./.pgo/small.binpack --batch-size 2048 --l1=1024 --features=Full_Threats+HalfKAv2_hm^ --epoch-size 10000 --max_epochs=2 --swa-start-epoch=2 --default_root_dir \"{test_dir_str}\" --resume-from-model=\"{test_dir_str}\"/lightning_logs/version_0/checkpoints/last.pt --validation-size=5000 {train_device_arg} {train_workers_arg}",
+        f"{python_executable} -u train.py ./.pgo/small.binpack --batch-size 2048 --l1=1024 --features=Full_Threats+HalfKAv2_hm^ --epoch-size 10000 --max_epochs=2 --swa-start-epoch=2 --default_root_dir \"{test_dir_str}\" --resume-from-model=\"{test_dir_str}\"/lightning_logs/version_0/checkpoints/last.pt --validation-size=5000 {train_device_arg} {train_workers_arg} --save_top_k 1 --network_save_period 1",
 
-        f"{python_executable} -u train.py ./.pgo/small.binpack --batch-size 2048 --l1=1024 --features=Full_Threats+HalfKAv2_hm^ --epoch-size 10000 --max_epochs=4 --swa-start-epoch=2 --default_root_dir \"{test_dir_str}\" --resume-from-checkpoint=\"{test_dir_str}\"/lightning_logs/version_1/checkpoints/last.ckpt --validation-size=5000 {train_device_arg} {train_workers_arg}",
+        f"{python_executable} -u train.py ./.pgo/small.binpack --batch-size 2048 --l1=1024 --features=Full_Threats+HalfKAv2_hm^ --epoch-size 10000 --max_epochs=4 --swa-start-epoch=2 --default_root_dir \"{test_dir_str}\" --resume-from-checkpoint=\"{test_dir_str}\"/lightning_logs/version_1/checkpoints/last.ckpt --validation-size=5000 {train_device_arg} {train_workers_arg} --save_top_k 2 --network_save_period 2",
 
         f"{python_executable} -u serialize.py \"{test_dir_str}\"/lightning_logs/version_2/checkpoints/last.ckpt \"{test_dir_str}\"/lightning_logs/version_2/checkpoints/last.pt --features=Full_Threats+HalfKAv2_hm^ --l1=1024 {serialize_device_arg} {serialize_workers_arg}",
 

--- a/train.py
+++ b/train.py
@@ -9,7 +9,7 @@ import torch
 from torch import set_num_threads as t_set_num_threads
 from torch.utils.data import DataLoader
 from lightning.pytorch import loggers as pl_loggers
-from lightning.pytorch.callbacks import Callback, ModelCheckpoint
+from lightning.pytorch.callbacks import Callback
 
 import data_loader
 import model as M
@@ -41,20 +41,6 @@ class TimeLimitAfterCheckpoint(Callback):
             print(
                 f"[TimeLimit] Time limit reached ({elapsed:.1f}s), stopping after checkpoint."
             )
-
-
-class ConsolidatedCheckpoint(ModelCheckpoint):
-    def __init__(self, *args, **kwargs):
-        # We force this to True to decouple from the validation schedule
-        kwargs.setdefault("save_on_train_epoch_end", True)
-        kwargs.setdefault("monitor", None)
-        super().__init__(*args, **kwargs)
-
-    def on_train_end(self, trainer, pl_module):
-        if self.dirpath:
-            # Manually trigger a final save to last.ckpt
-            path = os.path.join(self.dirpath, "last.ckpt")
-            trainer.save_checkpoint(path)
 
 
 class SimpleLineLogger(Callback):
@@ -417,7 +403,7 @@ def main():
             print("Using default torch num_threads setting.")
         print("", flush=True)
 
-    checkpoint_callback = ConsolidatedCheckpoint(
+    checkpoint_callback = M.SimplePeriodicCheckpoint(
         save_last=args.save_last_network,
         every_n_epochs=args.network_save_period,
         save_top_k=args.save_top_k,
@@ -472,7 +458,7 @@ def main():
         callbacks=trainer_callbacks,
         log_every_n_steps=refresh_rate,
         enable_progress_bar=False,
-        enable_checkpointing=True,
+        enable_checkpointing=False, # we handle checkpointing in the callback to have more control
         benchmark=True,
         num_sanity_val_steps=0 if val is None else 2,
         check_val_every_n_epoch=args.check_val_every_n_epoch,


### PR DESCRIPTION
# Motivation

Native Lightning Callback `ModelCheckpoint` is very bloated and has one crucial limitation for our use-case:
- There is no (clean) mechanism to pause checkpointing during some periods.

This is a problem because no resuming is supported during SWA epochs. This means that checkpoints created during that time are non-functional and can overwrite crucial save-points leading to corrupted runs that have to be restarted.

This implementation handles the pause of checkpointing during SWA epochs.


# Other Benefits

Since we only use a small fraction of the bloated features offered by `ModelCheckpoint` this implementation is a lightweight alternative that is easier to maintain as `ModelCheckpoint` is poorly documented and has behavior that is difficult to understand. This lightweight implementation on the other hand is easy to parse and any behavior can be quickly deduced. If `ModelCheckpoint` does something weird, it takes A LOT more effort to debug!

Mainly:
- `ModelCheckpoint` does NOT automatically save a checkpoint at the end of training -- even when using `save-last` which is very counter-intuitive. This implementation always saves a checkpoint at the end of training -- without the need of any subclassing!
- `ModelCheckpoint`'s checkpoint frequency is depending on whether we use validation and on how often we validate! This is because its use is mainly tied to Monitor to keep the *best* checkpoints. Since we don't use any Monitor, this doesn't make any sense to us. We want checkpoints to be saved in a predictable frequency. As such this lightweight implementation saves checkpoints always at the save frequency.