### PR TITLE
[FIX] Mark FeaturedBatchStream and FenBatchStream as final & fix unused import

### DIFF
--- a/data_loader/cpp/training_data_loader_internal.h
+++ b/data_loader/cpp/training_data_loader_internal.h
@@ -86,7 +86,7 @@ protected:
     std::unique_ptr<training_data::BasicSfenInputStream> m_stream;
 };
 
-struct FeaturedBatchStream: Stream<SparseBatch> {
+struct FeaturedBatchStream final : Stream<SparseBatch> {
     using BaseType = Stream<SparseBatch>;
     static constexpr double worker_thread_ratio = 0.14;
 
@@ -138,7 +138,7 @@ private:
     Fen* m_fens;
 };
 
-struct FenBatchStream: Stream<FenBatch> {
+struct FenBatchStream final : Stream<FenBatch> {
     using BaseType = Stream<FenBatch>;
     static constexpr double worker_thread_ratio = 0.5;
 

--- a/data_loader/stream.py
+++ b/data_loader/stream.py
@@ -1,4 +1,5 @@
 import ctypes
+import os  # noqa: F401
 
 from ._native import c_lib, SparseBatchPtr, FenBatchPtr
 from .config import (


### PR DESCRIPTION
Bugs:
- compile_data_loader.sh emits warnings
- Pyteset for data_loader_ddp fails due to import error

Mark FeaturedBatchStream and FenBatchStream as final & fix unused import
- Marked FeaturedBatchStream and FenBatchStream as final in C++ to resolve virtual table compiler warnings.
- Added # noqa: F401 to import os in data_loader/stream.py to prevent Ruff linting from removing the import that is required by downstream tests.
