### PR TITLE
Calculate buckets on the fly

### DIFF
--- a/cross_check_eval.py
+++ b/cross_check_eval.py
@@ -71,8 +71,7 @@ def eval_model_batch(model: M.NNUEModel, batch: data_loader.SparseBatchPtr, devi
         black_indices,
         outcome,
         score,
-        psqt_indices,
-        layer_stack_indices,
+        piece_count,
     ) = batch.contents.get_tensors(device)
 
     evals = [
@@ -82,8 +81,7 @@ def eval_model_batch(model: M.NNUEModel, batch: data_loader.SparseBatchPtr, devi
             them,
             white_indices,
             black_indices,
-            psqt_indices,
-            layer_stack_indices,
+            piece_count,
             fake_quantize_acts=fake_quantize,
             fake_quantize_weights=fake_quantize,
         )

--- a/data_loader/_native.py
+++ b/data_loader/_native.py
@@ -73,10 +73,17 @@ class SparseBatch(ctypes.Structure):
         black_indices = int_block_gpu[size * max_active : 2 * size * max_active].view(size, max_active)
         piece_count_i32 = int_block_gpu[2 * size * max_active : 2 * size * max_active + size].view(size)
 
-        them = 1.0 - us
-        piece_count = piece_count_i32.to(dtype=torch.int64)
-        psqt_indices = (piece_count - 1) // 4
-        layer_stack_indices = psqt_indices
+        # Keep piece counts as int64 so callers can derive buckets on the target device.
+        if not us.is_cuda and use_pinned_memory:
+            them = torch.empty_like(us, pin_memory=True)
+            them.fill_(1.0)
+            them.sub_(us)
+
+            piece_count = torch.empty(size, dtype=torch.int64, device="cpu", pin_memory=True)
+            piece_count.copy_(piece_count_i32)
+        else:
+            them = 1.0 - us
+            piece_count = piece_count_i32.to(dtype=torch.int64)
 
         return (
             us,
@@ -85,8 +92,7 @@ class SparseBatch(ctypes.Structure):
             black_indices,
             outcome,
             score,
-            psqt_indices,
-            layer_stack_indices,
+            piece_count,
         )
 
 

--- a/ftperm.py
+++ b/ftperm.py
@@ -32,8 +32,10 @@ python serialize.py nn-5af11540bbfe.nnue permuted.nnue --features=HalfKAv2_hm^ -
 """
 
 import copy
-from dataclasses import dataclass, field, replace
 import time
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field, replace
 from typing import Callable, Generator, TypeAlias, Annotated, Union, Literal, TypeVar, Optional
 
 import tyro
@@ -536,7 +538,7 @@ def make_sparse_batch_provider(
     )
 
 
-def eval_ft(model: NNUEModel, batch: data_loader.SparseBatchPtr, device_str: str) -> torch.Tensor:
+def eval_ft(model: NNUEModel, batch: Iterable[torch.Tensor], device_str: str) -> torch.Tensor:
     with torch.no_grad():
         batch_tuple = tuple(
             batch_part.to(device=device_str) for batch_part in batch
@@ -548,9 +550,9 @@ def eval_ft(model: NNUEModel, batch: data_loader.SparseBatchPtr, device_str: str
             black_indices,
             outcome,
             score,
-            psqt_indices,
-            layer_stack_indices,
+            piece_count,
         ) = batch_tuple
+        psqt_indices, _  = model.calculate_buckets(piece_count)
         l0_, wpsqt, bpsqt = model.forward_ft(
             us,
             them,

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -232,18 +232,15 @@ class NNUE(L.LightningModule):
             black_indices,
             outcome,
             score,
-            psqt_indices,
-            layer_stack_indices,
+            piece_count,
         ) = batch
-
         scorenet = (
             self.model(
                 us,
                 them,
                 white_indices,
                 black_indices,
-                psqt_indices,
-                layer_stack_indices,
+                piece_count,
                 self.config.use_fake_act_quantization,
                 self.config.use_fake_weight_quantization
             )

--- a/model/model.py
+++ b/model/model.py
@@ -114,6 +114,12 @@ class NNUEModel(nn.Module):
 
         return l0_, wpsqt, bpsqt
 
+    def calculate_buckets(self, piece_count: torch.Tensor):
+        psqt_indices = (piece_count - 1) // 4
+        layer_stack_indices = psqt_indices
+
+        return psqt_indices, layer_stack_indices
+
 
     def forward(
         self,
@@ -121,11 +127,12 @@ class NNUEModel(nn.Module):
         them: torch.Tensor,
         white_indices: torch.Tensor,
         black_indices: torch.Tensor,
-        psqt_indices: torch.Tensor,
-        layer_stack_indices: torch.Tensor,
+        piece_count: torch.Tensor,
         fake_quantize_acts: bool=True,
         fake_quantize_weights: bool=True,
     ):
+        psqt_indices, layer_stack_indices = self.calculate_buckets(piece_count)
+
         l0_, wpsqt, bpsqt = self.forward_ft(
             us,
             them,

--- a/perf_sigmoid_fitter.py
+++ b/perf_sigmoid_fitter.py
@@ -71,8 +71,7 @@ def gather_statistics_from_batches(batches, bucket_size):
             black_indices,
             outcome,
             score,
-            psqt_indices,
-            layer_stack_indices,
+            piece_count,
         ) = batch
         batch_size = len(us)
         bucket = torch.round(score / bucket_size) * bucket_size


### PR DESCRIPTION
On top of https://github.com/official-stockfish/nnue-pytorch/pull/491 extraced from https://github.com/official-stockfish/nnue-pytorch/pull/484

Piece Count Packing (Optimization): Replaced psqt_indices and layer_stack_indices arrays with a single raw piece_count array. psqt_indices and layer_stack_indices are now calculated dynamically on the GPU in PyTorch (data_loader/_native.py):