### PR TITLE
docs: resolve weight-pruning forward reference in nnue.md (refs #127)

### DIFF
--- a/docs/nnue.md
+++ b/docs/nnue.md
@@ -1776,7 +1776,7 @@ For AVX2 such blocks must be at least 8 int32s (type of the output values) wide,
 
 There is some additional workload in the forward pass to support it, and it doesn't vectorize as nicely as in previous cases, but it might still be a win for some architectures.
 
-However, with this approach, the training needs to be aware of this and try to create those blocks of 0 weights without harming the network too much. This can be achieved with weight pruning, which will be described later. The inference code will be very similar to the linear layer with sparse inputs case.
+However, with this approach, the training needs to be aware of this and try to create those blocks of 0 weights without harming the network too much. This can be achieved with weight pruning. The inference code will be very similar to the linear layer with sparse inputs case.
 
 
 ```cpp


### PR DESCRIPTION
## Summary

Addresses one of the documentation TODOs tracked in #127 for `docs/nnue.md`.

### TODO addressed
- **"either write something about weight pruning or remove the mention that it will be described later in the document"** — The blocked-sparse-output linear layer section (around the "Linear layer with sparse input and blocked sparse output" subsection) stated that the zero weight blocks "can be achieved with weight pruning, which will be described later." Weight pruning is never actually described anywhere else in the document, and there is no pruning implementation anywhere in the repository to ground a real write-up on. To avoid fabricating technical content, this PR removes the dangling forward reference while keeping the (accurate) mention of weight pruning as the technique that produces the blocks of zero weights.

### TODOs still remaining (not addressed here)
- [ ] some results regarding net size
- [ ] about data used to train the nets (filtering, mirroring, etc.)
- [ ] make headings understandable without context
- [ ] consistent formatting (feature set names, net arch names, etc.)
- [ ] backprop math

These remaining items require external experiment data or substantial original technical writing that cannot be verified against the current codebase, so they are intentionally left for a follow-up.

Refs #127
