### PR TITLE
Use load_from_checkpoint for resume_from_model

### DIFF
--- a/config.py
+++ b/config.py
@@ -66,7 +66,7 @@ class TrainingConfig:
     """Torch seed to use."""
 
     resume_from_model: Optional[str] = None
-    """Initializes training using the weights from the given .pt model."""
+    """Initializes training using the weights from the given .ckpt model."""
 
     resume_from_checkpoint: Optional[str] = None
     """Initializes training using a given .ckpt model."""

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -58,6 +58,13 @@ class NNUE(L.LightningModule):
     ):
         super().__init__()
 
+        # Persist only the architecture-defining hyperparameters so that
+        # `load_from_checkpoint` can reconstruct the model with the correct
+        # shapes while the run-specific arguments (config, max_epoch, ...) are
+        # passed explicitly when resuming. We deliberately avoid pickling the
+        # whole config into the checkpoint to keep it robust against refactors.
+        self.save_hyperparameters("num_psqt_buckets", "num_ls_buckets")
+
         self.model: NNUEModel = NNUEModel(
             config.features,
             config.model_config,

--- a/train.py
+++ b/train.py
@@ -372,20 +372,24 @@ def main():
     else:
         assert os.path.exists(args.resume_from_model)
         try:
-            nnue = torch.load(
-                args.resume_from_model, weights_only=False, map_location="cpu"
+            # Load only the weights from the checkpoint and (re)initialize the
+            # run-specific arguments by passing them explicitly. This avoids the
+            # brittle post-init overwrite of attributes; the architecture-defining
+            # hyperparameters (num_psqt_buckets, num_ls_buckets) are restored from
+            # the checkpoint via `save_hyperparameters`.
+            nnue = M.NNUE.load_from_checkpoint(
+                args.resume_from_model,
+                config=args.nnue_lightning_config,
+                max_epoch=max_epoch,
+                num_batches_per_epoch=args.num_batches_per_epoch,
+                param_index=args.dataloader_config.param_index,
+                map_location="cpu",
             )
             nnue.train()
         except ModuleNotFoundError as e:
             raise RuntimeError(
                 f"Could not load checkpoint: {e}. The model to be resumed was probably saved with a different version of the code."
             )
-        # we can set the following here just like that because when resuming
-        # from .pt the optimizer is only created after the training is started
-        nnue.max_epoch = max_epoch
-        nnue.num_batches_per_epoch = args.num_batches_per_epoch
-        nnue.config = args.nnue_lightning_config
-        nnue.param_index = args.dataloader_config.param_index
 
     input_feature_name = nnue.model.input_feature_name
 


### PR DESCRIPTION
## Summary

Implements the approach discussed in #438: replace the brittle `resume_from_model` logic with PyTorch Lightning's `load_from_checkpoint`, passing the run-specific arguments explicitly.

### What it replaces

Previously, `train.py` resumed a model by loading a `.pt` with `torch.load(..., weights_only=False)` and then **overwriting** attributes (`max_epoch`, `num_batches_per_epoch`, `config`, `param_index`) on the already-constructed module. As noted in the issue, this is brittle: hyperparameters were effectively garbage from `serialize.py` and then patched again after load, which caused pain during the config refactor.

### What it does now

- `resume_from_model` now uses `M.NNUE.load_from_checkpoint(...)` (consistent with `serialize.py`, `cross_check_eval.py` and `model/utils/load_model.py`), passing `config`, `max_epoch`, `num_batches_per_epoch` and `param_index` directly to the constructor. The module is built correctly up front instead of being patched after the fact.
- Added `self.save_hyperparameters("num_psqt_buckets", "num_ls_buckets")` in the `NNUE` module so the architecture-defining hyperparameters are restored from the checkpoint, per the maintainer note that `save_hyperparameters` is needed to keep hyperparameters from the last run. The config dataclass is intentionally **not** pickled into the checkpoint, keeping it robust against future config refactors.
- Updated the `resume_from_model` docstring to reflect that it now takes a `.ckpt`.

Closes #438
