### PR TITLE
Fix visualize.py crash on current network architecture

### DIFF
--- a/visualize.py
+++ b/visualize.py
@@ -334,15 +334,20 @@ class NNUEVisualizer:
                 if self.args.ref_model:
                     l1_weights_ -= ref_layers[bucket_id][0].weight.data.numpy()
 
-                N = l1_weights_.size // (2 * self.M)
+                # The feature transformer outputs are pairwise-multiplied before
+                # the first fully-connected layer, so this layer takes L1 inputs
+                # (not 2 * L1) split into two equal perspective halves (our/their),
+                # each of size L1 // 2. The post-multiplication inputs no longer
+                # map one-to-one to the feature transformer neurons, so the
+                # sorted-neuron reordering is not applied here.
+                N = l1_weights_.shape[0]
+                half = l1_weights_.shape[1] // 2
 
-                l1_weights = np.zeros((2 * N, self.M))
+                l1_weights = np.zeros((2 * N, half))
 
                 for i in range(N):
-                    l1_weights[2 * i] = l1_weights_[i][self.sorted_input_neurons]
-                    l1_weights[2 * i + 1] = l1_weights_[i][
-                        self.M + self.sorted_input_neurons
-                    ]
+                    l1_weights[2 * i] = l1_weights_[i][:half]
+                    l1_weights[2 * i + 1] = l1_weights_[i][half : 2 * half]
                 return l1_weights, N
 
             def get_l2_weights(bucket_id, l2):


### PR DESCRIPTION
## Problem

`visualize.py` crashes on the current network architecture (issue #188). The original traceback was a feature-transformer reshape error in the old `NNUEReader`; that loading path has since been rewritten, but the visualization code still carried an assumption from the pre-pairwise-multiplication architecture and crashes when plotting the fully-connected weights.

## Root cause

The first fully-connected layer (`layer_stacks.l1`) used to receive two full perspective accumulators of size `L1` concatenated together (input width `2 * L1`). The architecture now pairwise-multiplies the feature-transformer output before this layer, halving the dimensionality, so `l1.at_index(i)` is `nn.Linear(L1, L2 + 1)` — its weight has only `L1` input columns.

`NNUEVisualizer.get_l1_weights` still assumed the old layout: with `self.M = L1`, it indexed

```python
l1_weights_[i][self.M + self.sorted_input_neurons]
```

i.e. columns `L1 .. 2*L1 - 1` of an `L1`-wide row, raising:

```
IndexError: index 1024 is out of bounds for axis 0 with size 1024
```

on a default-sized (`L1 = 1024`) network. `N = l1_weights_.size // (2 * self.M)` was also wrong, yielding half the real output-neuron count.

## Fix

Derive the dimensions from the actual weight tensor instead of the stale `self.M`/`sorted_input_neurons` assumption:

- `N = l1_weights_.shape[0]` (real output-neuron count).
- Split the `L1` inputs into two equal perspective halves of `L1 // 2` each (our/their), matching the pairwise-multiplied layout produced in `forward_ft`.

Because the post-multiplication inputs no longer map one-to-one to feature-transformer neurons, the sorted-neuron reordering is intentionally not applied to this layer. Minimal, surgical change confined to `get_l1_weights`.

## Verification

Full end-to-end runtime verification is pending: this environment has no `.nnue` sample net, and `import model` requires Python 3.11+ plus torch/lightning/torchmetrics which are not installed here. The dimensional logic was verified with a standalone NumPy simulation reproducing the exact layer shapes (`l1` weight `[L2+1, L1] = [32, 1024]`):

- Old code: `IndexError: index 1024 is out of bounds for axis 0 with size 1024` (reproduces #188).
- New code: succeeds, producing a `[2*(L2+1), L1//2] = [64, 512]` weight image.

`python -m py_compile visualize.py` passes.

Note: visualizing the *input* weights of composed feature sets (the new `Full_Threats+HalfKAv2_hm^` default) still needs separate reengineering as noted by @Sopel97; this PR restores the fully-connected weight/bias visualization that crashed for every current net, including plain `HalfKAv2_hm^` networks.

Refs #188

