### PR TITLE
Add mate score remapping

### DIFF
--- a/data_loader/cpp/lib/parallel_dataloader.h
+++ b/data_loader/cpp/lib/parallel_dataloader.h
@@ -347,7 +347,7 @@ namespace binpack
 
                             auto to_utc_tm = [](std::time_t time, std::tm& result)
                             {
-                                #if defined(_MSC_VER)
+                                #if defined(_MSC_VER) || defined(_WIN32)
                                 gmtime_s(&result, &time);
                                 #else
                                 gmtime_r(&time, &result);

--- a/model/config.py
+++ b/model/config.py
@@ -69,6 +69,12 @@ class LossParams:
     """weight boost parameter 2 (default=0.5)"""
     lambda_: Annotated[float, tyro.conf.arg(name="lambda")] = 1.0
     """1.0=train on evaluations, 0.0=train on game results, interpolates between (default=1.0)."""
+    tb_remap_base: float = 7000.0
+    """Tablebase score remapping base value (default=7000.0)"""
+    tb_remap_scale: float = 20000.0
+    """Tablebase score remapping scale value (default=20000.0)"""
+    tb_remap_decay: float = 0.8
+    """Tablebase score remapping decay parameter (default=0.8)"""
 
     def __post_init__(self):
         if (self.start_lambda is not None) != (self.end_lambda is not None):

--- a/model/lightning_module.py
+++ b/model/lightning_module.py
@@ -18,7 +18,34 @@ def _get_parameters(layers: list[nn.Module], get_biases: bool = False):
     ]
 
 
+def remap_tablebase_score(
+    score: Tensor,
+    base: float,
+    scale: float,
+    decay: float
+) -> Tensor:
+    mate_score = 32000
+    max_mate_ply = 245
+    tb_mate_threshold = mate_score - max_mate_ply
+
+    abs_score = score.abs()
+    is_mate = abs_score >= tb_mate_threshold
+
+    plies = (mate_score - abs_score).clamp(min=0)
+    remapped_abs = base + (decay ** plies) * scale
+    remapped_score = torch.where(score < 0, -remapped_abs, remapped_abs)
+
+    return torch.where(is_mate, remapped_score, score)
+
+
 def calculate_sf_loss(scorenet, score, outcome, loss_params, actual_lambda):
+    score = remap_tablebase_score(
+        score,
+        base=loss_params.tb_remap_base,
+        scale=loss_params.tb_remap_scale,
+        decay=loss_params.tb_remap_decay
+    )
+
     # convert the network and search scores to an estimate match result
     # based on the win_rate_model, with scalings and offsets optimized
     q = (scorenet - loss_params.in_offset) / loss_params.in_scaling


### PR DESCRIPTION
Remapping of DTM DTM scores from tablebase positions.

~32k scores are hard for the net to learn as they are far away from normal labels. Additionally `#100` is scored basically the same as ``#1``. A simple configurable remap fixes both.