### PR TITLE
Restore Ruff Lint

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -27,3 +27,4 @@ exclude = [
     "venv",
     "ranger21.py"
 ]
+lint.select = ["E4", "E7", "E9", "F"]


### PR DESCRIPTION
In [v0.16](https://astral.sh/blog/ruff-v0.16.0), ruff significantly expanded its default rule set.
This patch reverts that change and uses the old, very limited rule set.